### PR TITLE
chore: add note to example readmes about building main package

### DIFF
--- a/examples/react/file-upload/README.md
+++ b/examples/react/file-upload/README.md
@@ -2,5 +2,28 @@
 
 To run this example:
 
-- `npm install`
-- `npm start`
+- Clone the w3ui repository and enter the `w3ui` directory
+
+  ```sh
+  git clone https://github.com/web3-storage/w3ui
+  cd w3ui
+  ```
+- Build the w3ui packages in the repo root directory
+
+  ```sh
+  npm install
+  npm run build
+  ```
+
+- Change to this example directory and install dependencies
+
+  ```sh
+  cd examples/react/file-upload
+  npm install
+  ```
+
+- Run the example
+
+  ```sh
+  npm start
+  ```

--- a/examples/react/multi-file-upload/README.md
+++ b/examples/react/multi-file-upload/README.md
@@ -2,5 +2,28 @@
 
 To run this example:
 
-- `npm install`
-- `npm start`
+- Clone the w3ui repository and enter the `w3ui` directory
+
+  ```sh
+  git clone https://github.com/web3-storage/w3ui
+  cd w3ui
+  ```
+- Build the w3ui packages in the repo root directory
+
+  ```sh
+  npm install
+  npm run build
+  ```
+
+- Change to this example directory and install dependencies
+
+  ```sh
+  cd examples/react/multi-file-upload
+  npm install
+  ```
+
+- Run the example
+
+  ```sh
+  npm start
+  ```

--- a/examples/react/sign-up-in/README.md
+++ b/examples/react/sign-up-in/README.md
@@ -2,5 +2,29 @@
 
 To run this example:
 
-- `npm install`
-- `npm start`
+- Clone the w3ui repository and enter the `w3ui` directory
+
+  ```sh
+  git clone https://github.com/web3-storage/w3ui
+  cd w3ui
+  ```
+- Build the w3ui packages in the repo root directory
+
+  ```sh
+  npm install
+  npm run build
+  ```
+
+- Change to this example directory and install dependencies
+
+  ```sh
+  cd examples/react/sign-up-in
+  npm install
+  ```
+
+- Run the example
+
+  ```sh
+  npm start
+  ```
+


### PR DESCRIPTION
This just adds a couple lines to the example READMEs to make sure people build the main `w3ui` packages before running the examples.  Don't know if there's an issue for it, but closes @jchris's slack ping :smile: