### PR TITLE
chore: add readmes to example folders with overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 * **Single File Upload** [React](https://github.com/web3-storage/w3ui/tree/main/examples/react/file-upload) | [Solid](https://github.com/web3-storage/w3ui/tree/main/examples/solid/file-upload) | [Vue](https://github.com/web3-storage/w3ui/tree/main/examples/vue/file-upload)
 
-    The simplist file upload using a file input. Includes the auth flow from "Sign up / Sign in".
+    The simplest file upload using a file input. Includes the auth flow from "Sign up / Sign in".
 
 * **Multiple File Upload** [React](https://github.com/web3-storage/w3ui/tree/main/examples/react/multi-file-upload) | [Solid](https://github.com/web3-storage/w3ui/tree/main/examples/solid/multi-file-upload)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,19 @@
+# w3ui examples
+
+This directory contains example projects that use w3ui in each of the supported frontend frameworks.
+
+* **Sign up / Sign in** [React](https://github.com/web3-storage/w3ui/tree/main/examples/react/sign-up-in) | [Solid](https://github.com/web3-storage/w3ui/tree/main/examples/solid/sign-up-in) | [Vue](https://github.com/web3-storage/w3ui/tree/main/examples/vue/sign-up-in)
+
+    Demonstrates email autentication flow for the service, including private key creation and email validation.
+
+* **Single File Upload** [React](https://github.com/web3-storage/w3ui/tree/main/examples/react/file-upload) | [Solid](https://github.com/web3-storage/w3ui/tree/main/examples/solid/file-upload) | [Vue](https://github.com/web3-storage/w3ui/tree/main/examples/vue/file-upload)
+
+    The simplest file upload using a file input. Includes the auth flow from "Sign up / Sign in".
+
+* **Multiple File Upload** [React](https://github.com/web3-storage/w3ui/tree/main/examples/react/multi-file-upload) | [Solid](https://github.com/web3-storage/w3ui/tree/main/examples/solid/multi-file-upload)
+
+    Slightly more complicated file and directory upload. Includes the auth flow from "Sign up / Sign in".
+
+* **Uploads List** [React](https://github.com/web3-storage/w3ui/tree/main/examples/react/uploads-list) | [Solid](https://github.com/web3-storage/w3ui/tree/main/examples/solid/uploads-list)
+
+    A demo of the list of uploads that have been made to an account.

--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -1,0 +1,19 @@
+# w3ui React examples
+
+Example projects for using w3ui with [React](https://reactjs.org).
+
+* [**Sign up / Sign in**](https://github.com/web3-storage/w3ui/tree/main/examples/react/sign-up-in)
+
+    Demonstrates email autentication flow for the service, including private key creation and email validation.
+
+* [**Single File Upload**](https://github.com/web3-storage/w3ui/tree/main/examples/react/file-upload)
+
+    The simplest file upload using a file input. Includes the auth flow from "Sign up / Sign in".
+
+* [**Multiple File Upload**](https://github.com/web3-storage/w3ui/tree/main/examples/react/multi-file-upload)
+
+    Slightly more complicated file and directory upload. Includes the auth flow from "Sign up / Sign in".
+
+* [**Uploads List**](https://github.com/web3-storage/w3ui/tree/main/examples/react/uploads-list)
+
+    A demo of the list of uploads that have been made to an account.

--- a/examples/solid/README.md
+++ b/examples/solid/README.md
@@ -1,0 +1,19 @@
+# w3ui Solid examples
+
+This directory contains example projects that use w3ui with [Solid](https://www.solidjs.com/).
+
+* [**Sign up / Sign in**](https://github.com/web3-storage/w3ui/tree/main/examples/solid/sign-up-in)
+
+    Demonstrates email autentication flow for the service, including private key creation and email validation.
+
+* [**Single File Upload**](https://github.com/web3-storage/w3ui/tree/main/examples/solid/file-upload)
+
+    The simplest file upload using a file input. Includes the auth flow from "Sign up / Sign in".
+
+* [**Multiple File Upload**](https://github.com/web3-storage/w3ui/tree/main/examples/solid/multi-file-upload)
+
+    Slightly more complicated file and directory upload. Includes the auth flow from "Sign up / Sign in".
+
+* [**Uploads List**](https://github.com/web3-storage/w3ui/tree/main/examples/solid/uploads-list)
+
+    A demo of the list of uploads that have been made to an account.

--- a/examples/vue/README.md
+++ b/examples/vue/README.md
@@ -1,0 +1,11 @@
+# w3ui Vue examples
+
+This directory contains example projects that use w3ui with [Vue](https://vuejs.org).
+
+* [**Sign up / Sign in**](https://github.com/web3-storage/w3ui/tree/main/examples/vue/sign-up-in)
+
+    Demonstrates email autentication flow for the service, including private key creation and email validation.
+
+* [**Single File Upload**](https://github.com/web3-storage/w3ui/tree/main/examples/vue/file-upload)
+
+    The simplest file upload using a file input. Includes the auth flow from "Sign up / Sign in".


### PR DESCRIPTION
This just copies the example "index" from the main README to `examples/README.md` and the framework-specific example dirs.

This is mostly so we have something to link to from the "getting started resources" blog post I'm working on. 

@alanshaw LMK if you think the framework-specific ones add too much maintenance overhead... I don't love that I just added a bunch of places to update as things change. I think we can get away with just linking to `examples/README.md` from the blog post instead, but it feels nice as a viewer to have a bit of context when browsing the subdirs on github.