### PR TITLE
fix: uploads listing

### DIFF
--- a/examples/vanilla/file-upload/src/upload.js
+++ b/examples/vanilla/file-upload/src/upload.js
@@ -1,5 +1,5 @@
 import { loadDefaultIdentity } from '@w3ui/keyring-core'
-import { uploadCarChunks, encodeFile, chunkBlocks } from '@w3ui/uploader-core'
+import { uploadCarChunks, encodeFile, chunkBlocks, createUpload } from '@w3ui/uploader-core'
 
 const SELECTORS = {
   uploadForm: '#upload-form',
@@ -43,13 +43,13 @@ export class UploadFileForm extends window.HTMLElement {
 
     try {
       this.toggleEncoding()
-      const { cid, blocks } = await encodeFile(this.file)
-      cid.then(cid => {
-        this.cid = cid
-        this.toggleUploading()
-      })
+      const { cid: cidPromise, blocks } = await encodeFile(this.file)
       const chunks = chunkBlocks(blocks)
-      await uploadCarChunks(identity.signingPrincipal, chunks)
+      const carCids = await uploadCarChunks(identity.signingPrincipal, chunks)
+      const cid = await cidPromise
+      await createUpload(identity.signingPrincipal, cid, carCids)
+      this.cid = cid
+      this.toggleUploading()
     } catch (error) {
       this.toggleUploadError()
     } finally {

--- a/examples/vanilla/multi-file-upload/src/upload.js
+++ b/examples/vanilla/multi-file-upload/src/upload.js
@@ -1,5 +1,5 @@
 import { loadDefaultIdentity } from '@w3ui/keyring-core'
-import { uploadCarChunks, encodeFile, encodeDirectory, chunkBlocks } from '@w3ui/uploader-core'
+import { uploadCarChunks, encodeFile, encodeDirectory, chunkBlocks, createUpload } from '@w3ui/uploader-core'
 
 const SELECTORS = {
   uploadForm: '#upload-form',
@@ -68,15 +68,14 @@ export class UploadFileForm extends window.HTMLElement {
         encodeFunction = encodeFile
       }
 
-      const { cid, blocks } = encodeFunction(this.files)
-
-      cid.then(cid => {
-        this.cid = cid
-        this.toggleUploading()
-      })
-
+      const { cid: cidPromise, blocks } = encodeFunction(this.files)
       const chunks = chunkBlocks(blocks)
-      await uploadCarChunks(identity.signingPrincipal, chunks)
+      const carCids = await uploadCarChunks(identity.signingPrincipal, chunks)
+      const cid = await cidPromise
+      await createUpload(identity.signingPrincipal, cid, carCids)
+
+      this.cid = cid
+      this.toggleUploading()
     } catch (error) {
       console.log(error)
       this.toggleUploadError()

--- a/package-lock.json
+++ b/package-lock.json
@@ -4444,8 +4444,9 @@
       }
     },
     "node_modules/@ucanto/validator": {
-      "version": "1.0.1",
-      "license": "(Apache-2.0 AND MIT)",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@ucanto/validator/-/validator-1.0.2.tgz",
+      "integrity": "sha512-SFjS/8FDOwzPNM29brT6wgbE+HXD8iQnHR3aeqEgzIUL7j56kluZykfVWD0xR8oLn8vYzNqJqf60YeFAbIBsqg==",
       "dependencies": {
         "@ipld/car": "^4.1.5",
         "@ipld/dag-cbor": "^7.0.3",
@@ -4782,8 +4783,9 @@
       }
     },
     "node_modules/@web3-storage/access": {
-      "version": "1.0.0",
-      "license": "(Apache-2.0 OR MIT)",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@web3-storage/access/-/access-2.1.1.tgz",
+      "integrity": "sha512-8MGs3gY6dn/KrJE+X4GDnwrPXaPgm5lvGJKFJpMdYVBtTUjfWQx9mhdYErs2nE2JEt9tKubCfe1rgodZ1b+7gA==",
       "dependencies": {
         "@ipld/car": "^4.1.5",
         "@ipld/dag-ucan": "3.0.0-beta",
@@ -4795,7 +4797,7 @@
         "@ucanto/principal": "^1.0.1",
         "@ucanto/server": "^1.0.2",
         "@ucanto/transport": "^1.0.1",
-        "@ucanto/validator": "^1.0.1",
+        "@ucanto/validator": "^1.0.2",
         "@web-std/fetch": "^4.1.0",
         "bigint-mod-arith": "^3.1.1",
         "conf": "^10.1.2",
@@ -19313,7 +19315,7 @@
       "dependencies": {
         "@ucanto/interface": "^1.0.0",
         "@ucanto/principal": "^1.0.1",
-        "@web3-storage/access": "^1.0.0",
+        "@web3-storage/access": "^2.1.1",
         "multiformats": "^9.8.1"
       }
     },
@@ -19330,7 +19332,7 @@
     },
     "packages/react-uploader": {
       "name": "@w3ui/react-uploader",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@w3ui/uploader-core": "^2.0.0",
@@ -19343,7 +19345,7 @@
     },
     "packages/react-uploads-list": {
       "name": "@w3ui/react-uploads-list",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@w3ui/uploads-list-core": "^1.0.1"
@@ -19366,7 +19368,7 @@
     },
     "packages/solid-uploader": {
       "name": "@w3ui/solid-uploader",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@w3ui/uploader-core": "^2.0.0",
@@ -19379,7 +19381,7 @@
     },
     "packages/solid-uploads-list": {
       "name": "@w3ui/solid-uploads-list",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@w3ui/uploads-list-core": "^1.0.1"
@@ -19391,7 +19393,7 @@
     },
     "packages/uploader-core": {
       "name": "@w3ui/uploader-core",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/car": "^4.1.5",
@@ -19399,7 +19401,7 @@
         "@ucanto/interface": "^1.0.0",
         "@ucanto/principal": "^1.0.1",
         "@ucanto/transport": "^1.0.1",
-        "@web3-storage/access": "^1.0.0",
+        "@web3-storage/access": "^2.1.1",
         "multiformats": "^9.8.1",
         "p-retry": "^5.1.1",
         "streaming-iterables": "^7.1.0"
@@ -19513,7 +19515,7 @@
       "dependencies": {
         "@ucanto/interface": "^1.0.0",
         "@ucanto/principal": "^1.0.1",
-        "@web3-storage/access": "^1.0.0",
+        "@web3-storage/access": "^2.1.1",
         "multiformats": "^9.9.0"
       }
     },
@@ -19530,7 +19532,7 @@
     },
     "packages/vue-uploader": {
       "name": "@w3ui/vue-uploader",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@w3ui/uploader-core": "^2.0.0",
@@ -19543,7 +19545,7 @@
     },
     "packages/vue-uploads-list": {
       "name": "@w3ui/vue-uploads-list",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@w3ui/uploads-list-core": "^1.0.1",
@@ -22012,7 +22014,9 @@
       }
     },
     "@ucanto/validator": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@ucanto/validator/-/validator-1.0.2.tgz",
+      "integrity": "sha512-SFjS/8FDOwzPNM29brT6wgbE+HXD8iQnHR3aeqEgzIUL7j56kluZykfVWD0xR8oLn8vYzNqJqf60YeFAbIBsqg==",
       "requires": {
         "@ipld/car": "^4.1.5",
         "@ipld/dag-cbor": "^7.0.3",
@@ -22340,7 +22344,7 @@
       "requires": {
         "@ucanto/interface": "^1.0.0",
         "@ucanto/principal": "^1.0.1",
-        "@web3-storage/access": "^1.0.0",
+        "@web3-storage/access": "^2.1.1",
         "multiformats": "^9.8.1"
       }
     },
@@ -22391,7 +22395,7 @@
         "@ucanto/principal": "^1.0.1",
         "@ucanto/transport": "^1.0.1",
         "@web-std/file": "^3.0.2",
-        "@web3-storage/access": "^1.0.0",
+        "@web3-storage/access": "^2.1.1",
         "blockstore-core": "^1.0.5",
         "ipfs-unixfs-exporter": "^7.0.11",
         "multiformats": "^9.8.1",
@@ -22478,7 +22482,7 @@
       "requires": {
         "@ucanto/interface": "^1.0.0",
         "@ucanto/principal": "^1.0.1",
-        "@web3-storage/access": "^1.0.0",
+        "@web3-storage/access": "^2.1.1",
         "multiformats": "^9.9.0"
       }
     },
@@ -22549,7 +22553,9 @@
       }
     },
     "@web3-storage/access": {
-      "version": "1.0.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@web3-storage/access/-/access-2.1.1.tgz",
+      "integrity": "sha512-8MGs3gY6dn/KrJE+X4GDnwrPXaPgm5lvGJKFJpMdYVBtTUjfWQx9mhdYErs2nE2JEt9tKubCfe1rgodZ1b+7gA==",
       "requires": {
         "@ipld/car": "^4.1.5",
         "@ipld/dag-ucan": "3.0.0-beta",
@@ -22561,7 +22567,7 @@
         "@ucanto/principal": "^1.0.1",
         "@ucanto/server": "^1.0.2",
         "@ucanto/transport": "^1.0.1",
-        "@ucanto/validator": "^1.0.1",
+        "@ucanto/validator": "^1.0.2",
         "@web-std/fetch": "^4.1.0",
         "bigint-mod-arith": "^3.1.1",
         "conf": "^10.1.2",

--- a/packages/keyring-core/package.json
+++ b/packages/keyring-core/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@ucanto/interface": "^1.0.0",
     "@ucanto/principal": "^1.0.1",
-    "@web3-storage/access": "^1.0.0",
+    "@web3-storage/access": "^2.1.1",
     "multiformats": "^9.8.1"
   }
 }

--- a/packages/keyring-core/src/index.ts
+++ b/packages/keyring-core/src/index.ts
@@ -1,7 +1,8 @@
 import { Principal, SigningPrincipal } from '@ucanto/principal'
 import type { Delegation, SigningPrincipal as ISigningPrincipal } from '@ucanto/interface'
 import * as Access from '@web3-storage/access'
-import { IdentityRegister } from '@web3-storage/access/types'
+// @ts-expect-error
+import { IdentityRegister } from '@web3-storage/access/capabilities/types'
 import { base64pad } from 'multiformats/bases/base64'
 
 // Production

--- a/packages/uploader-core/package.json
+++ b/packages/uploader-core/package.json
@@ -29,7 +29,7 @@
     "@ucanto/interface": "^1.0.0",
     "@ucanto/principal": "^1.0.1",
     "@ucanto/transport": "^1.0.1",
-    "@web3-storage/access": "^1.0.0",
+    "@web3-storage/access": "^2.1.1",
     "multiformats": "^9.8.1",
     "p-retry": "^5.1.1",
     "streaming-iterables": "^7.1.0"

--- a/packages/uploads-list-core/package.json
+++ b/packages/uploads-list-core/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@ucanto/interface": "^1.0.0",
     "@ucanto/principal": "^1.0.1",
-    "@web3-storage/access": "^1.0.0",
+    "@web3-storage/access": "^2.1.1",
     "multiformats": "^9.9.0"
   }
 }


### PR DESCRIPTION
This PR fixes the uploads listing by calling the `upload/list` capability.

After a chunked upload is complete, the uploader now calls `upload/add` to register an "upload" and associate multiple CAR files together.

`upload/list` capability will list out the uploads registered using the `upload/add` call.

There's no breaking API changes but existing uploads will no longer be displayed in the list since they were not registered using `upload/add`.

supersedes https://github.com/web3-storage/w3ui/pull/103