### PR TITLE
fix: Use cloneNode for vanilla templates

### DIFF
--- a/examples/vanilla/file-upload/src/register.js
+++ b/examples/vanilla/file-upload/src/register.js
@@ -54,7 +54,7 @@ export class RegisterForm extends window.HTMLElement {
   }
 
   toggleConfirmation () {
-    const templateContent = this.confirmationTemplate$.content
+    const templateContent = this.confirmationTemplate$.content.cloneNode(true)
     this.replaceChildren(this.formatTemplateContent(templateContent))
     this.signOutButton$ = document.querySelector(SELECTORS.signOutButton)
     this.signOutButton$.addEventListener('click', this.signOutHandler)
@@ -65,7 +65,7 @@ export class RegisterForm extends window.HTMLElement {
   }
 
   toggleVerification () {
-    const templateContent = this.verificationTemplate$.content
+    const templateContent = this.verificationTemplate$.content.cloneNode(true)
     this.replaceChildren(this.formatTemplateContent(templateContent))
     this.cancelRegistrationButton$ = document.querySelector(SELECTORS.cancelRegistrationButton)
     this.cancelRegistrationButton$.addEventListener('click', this.cancelRegistrationHandler)

--- a/examples/vanilla/file-upload/src/upload.js
+++ b/examples/vanilla/file-upload/src/upload.js
@@ -22,7 +22,7 @@ export class UploadFileForm extends window.HTMLElement {
   }
 
   async connectedCallback () {
-    const templateContent = this.uploadFormTemplate$.content
+    const templateContent = this.uploadFormTemplate$.content.cloneNode(true)
     this.replaceChildren(templateContent)
     this.handleFileUpload = this.handleFileUpload.bind(this)
     this.form$ = document.querySelector(SELECTORS.uploadForm)
@@ -58,22 +58,22 @@ export class UploadFileForm extends window.HTMLElement {
   }
 
   toggleEncoding () {
-    const templateContent = this.encodingTemplate$.content
+    const templateContent = this.encodingTemplate$.content.cloneNode(true)
     this.replaceChildren(this.formatEncodingTemplateContent(templateContent))
   }
 
   toggleUploading () {
-    const templateContent = this.uploadingTemplate$.content
+    const templateContent = this.uploadingTemplate$.content.cloneNode(true)
     this.replaceChildren(this.formatUploadingTemplateContent(templateContent))
   }
 
   toggleUploadComplete () {
-    const templateContent = this.uploadCompleteTemplate$.content
+    const templateContent = this.uploadCompleteTemplate$.content.cloneNode(true)
     this.replaceChildren(this.formatUploadCompleteTemplateContent(templateContent))
   }
 
   toggleUploadError () {
-    const templateContent = this.uploadErrorTemplate$.content
+    const templateContent = this.uploadErrorTemplate$.content.cloneNode(true)
     this.replaceChildren(this.formatUploadErrorTemplateContent(templateContent))
   }
 

--- a/examples/vanilla/multi-file-upload/src/register.js
+++ b/examples/vanilla/multi-file-upload/src/register.js
@@ -54,7 +54,7 @@ export class RegisterForm extends window.HTMLElement {
   }
 
   toggleConfirmation () {
-    const templateContent = this.confirmationTemplate$.content
+    const templateContent = this.confirmationTemplate$.content.cloneNode(true)
     this.replaceChildren(this.formatTemplateContent(templateContent))
     this.signOutButton$ = document.querySelector(SELECTORS.signOutButton)
     this.signOutButton$.addEventListener('click', this.signOutHandler)
@@ -65,7 +65,7 @@ export class RegisterForm extends window.HTMLElement {
   }
 
   toggleVerification () {
-    const templateContent = this.verificationTemplate$.content
+    const templateContent = this.verificationTemplate$.content.cloneNode(true)
     this.replaceChildren(this.formatTemplateContent(templateContent))
     this.cancelRegistrationButton$ = document.querySelector(SELECTORS.cancelRegistrationButton)
     this.cancelRegistrationButton$.addEventListener('click', this.cancelRegistrationHandler)

--- a/examples/vanilla/multi-file-upload/src/upload.js
+++ b/examples/vanilla/multi-file-upload/src/upload.js
@@ -85,22 +85,22 @@ export class UploadFileForm extends window.HTMLElement {
   }
 
   toggleEncoding () {
-    const templateContent = this.encodingTemplate$.content
+    const templateContent = this.encodingTemplate$.content.cloneNode(true)
     this.replaceChildren(this.formatEncodingTemplateContent(templateContent))
   }
 
   toggleUploading () {
-    const templateContent = this.uploadingTemplate$.content
+    const templateContent = this.uploadingTemplate$.content.cloneNode(true)
     this.replaceChildren(this.formatUploadingTemplateContent(templateContent))
   }
 
   toggleUploadComplete () {
-    const templateContent = this.uploadCompleteTemplate$.content
+    const templateContent = this.uploadCompleteTemplate$.content.cloneNode(true)
     this.replaceChildren(this.formatUploadCompleteTemplateContent(templateContent))
   }
 
   toggleUploadError () {
-    const templateContent = this.uploadErrorTemplate$.content
+    const templateContent = this.uploadErrorTemplate$.content.cloneNode(true)
     this.replaceChildren(this.formatUploadErrorTemplateContent(templateContent))
   }
 
@@ -133,7 +133,7 @@ export class UploadFileForm extends window.HTMLElement {
   }
 
   async connectedCallback () {
-    const templateContent = this.uploadFormTemplate$.content
+    const templateContent = this.uploadFormTemplate$.content.cloneNode(true)
     this.replaceChildren(templateContent)
     this.handleFileUpload = this.handleFileUpload.bind(this)
     this.form$ = document.querySelector(SELECTORS.uploadForm)

--- a/examples/vanilla/sign-up-in/src/main.js
+++ b/examples/vanilla/sign-up-in/src/main.js
@@ -58,14 +58,14 @@ export class RegisterForm extends window.HTMLElement {
   }
 
   toggleConfirmation () {
-    const templateContent = this.confirmationTemplate$.content
+    const templateContent = this.confirmationTemplate$.content.cloneNode(true)
     this.replaceChildren(this.formatTemplateContent(templateContent))
     this.signOutButton$ = document.querySelector(SELECTORS.signOutButton)
     this.signOutButton$.addEventListener('click', this.signOutHandler)
   }
 
   toggleVerification () {
-    const templateContent = this.verificationTemplate$.content
+    const templateContent = this.verificationTemplate$.content.cloneNode(true)
     this.replaceChildren(this.formatTemplateContent(templateContent))
     this.cancelRegistrationButton$ = document.querySelector(SELECTORS.cancelRegistrationButton)
     this.cancelRegistrationButton$.addEventListener('click', this.cancelRegistrationHandler)

--- a/examples/vanilla/uploads-list/src/register.js
+++ b/examples/vanilla/uploads-list/src/register.js
@@ -54,7 +54,7 @@ export class RegisterForm extends window.HTMLElement {
   }
 
   toggleConfirmation () {
-    const templateContent = this.confirmationTemplate$.content
+    const templateContent = this.confirmationTemplate$.content.cloneNode(true)
     this.replaceChildren(this.formatTemplateContent(templateContent))
     this.signOutButton$ = document.querySelector(SELECTORS.signOutButton)
     this.signOutButton$.addEventListener('click', this.signOutHandler)
@@ -65,7 +65,7 @@ export class RegisterForm extends window.HTMLElement {
   }
 
   toggleVerification () {
-    const templateContent = this.verificationTemplate$.content
+    const templateContent = this.verificationTemplate$.content.cloneNode(true)
     this.replaceChildren(this.formatTemplateContent(templateContent))
     this.cancelRegistrationButton$ = document.querySelector(SELECTORS.cancelRegistrationButton)
     this.cancelRegistrationButton$.addEventListener('click', this.cancelRegistrationHandler)


### PR DESCRIPTION
When extending the file-upload to reset the element after initial upload, this addresses the [DocumentFragment
pitfall](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template#avoiding_documentfragment_pitfall).