### PR TITLE
chore: move Uploader into react-uploader package

### DIFF
--- a/examples/react/ui/src/ContentPage.js
+++ b/examples/react/ui/src/ContentPage.js
@@ -1,6 +1,6 @@
 import React from 'react'
-import { Uploader, SimpleUploader } from '@w3ui/react-ui'
-import { UploaderProvider, useUploader } from '@w3ui/react-uploader'
+import { SimpleUploader } from '@w3ui/react-ui'
+import { Uploader, UploaderProvider, useUploader } from '@w3ui/react-uploader'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { a11yDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 

--- a/packages/react-ui/src/SimpleUploader.tsx
+++ b/packages/react-ui/src/SimpleUploader.tsx
@@ -1,8 +1,8 @@
 import React, { useContext } from 'react'
 import { CARMetadata } from '@w3ui/uploader-core'
+import Uploader, { UploaderContext } from '@w3ui/react-uploader';
 import { Link, Version } from 'multiformats'
 
-import Uploader, { UploaderContext } from './Uploader';
 
 export const Uploading = ({ file, storedDAGShards }: { file?: File, storedDAGShards?: CARMetadata[] }) => (
   <div className="uploading">

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -1,2 +1,1 @@
-export * from './Uploader'
 export * from './SimpleUploader'

--- a/packages/react-uploader/src/Uploader.tsx
+++ b/packages/react-uploader/src/Uploader.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, createContext, useState } from 'react'
-import { useUploader, CARMetadata } from '@w3ui/react-uploader'
 import { Link, Version } from 'multiformats'
+import { CARMetadata } from '@w3ui/uploader-core'
+import { useUploader } from './providers/Uploader'
 
 export type UploaderContextValue = {
   storedDAGShards?: CARMetadata[],
@@ -14,7 +15,7 @@ export type UploaderContextValue = {
 }
 
 export const UploaderContext = createContext<UploaderContextValue>({
-  setFile: () => {}
+  setFile: () => { }
 })
 
 export type UploaderProps = {
@@ -59,7 +60,7 @@ Uploader.Input = (props: any) => {
   )
 }
 
-Uploader.Form = ({ children, ...props }: {children: React.ReactNode} & any) => {
+Uploader.Form = ({ children, ...props }: { children: React.ReactNode } & any) => {
   const { handleUploadSubmit } = useContext(UploaderContext)
   return (
     <form onSubmit={handleUploadSubmit} {...props}>

--- a/packages/react-uploader/src/Uploader.tsx
+++ b/packages/react-uploader/src/Uploader.tsx
@@ -1,31 +1,43 @@
-import React, { useContext, createContext, useState } from 'react'
+import React, { useContext, useMemo, createContext, useState } from 'react'
 import { Link, Version } from 'multiformats'
-import { CARMetadata } from '@w3ui/uploader-core'
+import { CARMetadata, UploaderContextState, UploaderContextActions } from '@w3ui/uploader-core'
 import { useUploader } from './providers/Uploader'
 
-export type UploaderContextValue = {
-  storedDAGShards?: CARMetadata[],
-  file?: File,
-  setFile: React.Dispatch<React.SetStateAction<File | undefined>>,
-  dataCid?: Link<unknown, number, number, Version>,
+export type UploaderComponentContextState = UploaderContextState & {
   status?: string,
   error?: any,
+  file?: File,
   handleUploadSubmit?: (e: Event) => void
-
+  dataCid?: Link<unknown, number, number, Version>,
+  storedDAGShards?: CARMetadata[],
 }
 
-export const UploaderContext = createContext<UploaderContextValue>({
-  setFile: () => { }
-})
+export type UploaderComponentContextActions = UploaderContextActions & {
+  setFile: React.Dispatch<React.SetStateAction<File | undefined>>
+}
 
-export type UploaderProps = {
-  children: React.ReactNode,
+export type UploaderComponentContextValue = [
+  state: UploaderComponentContextState,
+  actions: UploaderComponentContextActions
+]
+
+const UploaderComponentContext = createContext<UploaderComponentContextValue>([
+  { storedDAGShards: [] },
+  {
+    setFile: () => { throw new Error('missing set file function') },
+    uploadFile: async () => { throw new Error('missing uploader context provider') },
+    uploadDirectory: async () => { throw new Error('missing uploader context provider') }
+  }
+])
+
+export type HeadlessUploaderProps = {
+  children?: JSX.Element,
 }
 
 export const Uploader = ({
   children,
-}: UploaderProps) => {
-  const [{ storedDAGShards }, uploader] = useUploader()
+}: HeadlessUploaderProps) => {
+  const [uploaderState, uploaderActions] = useUploader()
   const [file, setFile] = useState<File>()
   const [dataCid, setDataCid] = useState<Link<unknown, number, number, Version>>()
   const [status, setStatus] = useState('')
@@ -36,37 +48,49 @@ export const Uploader = ({
     if (file) {
       try {
         setStatus('uploading')
-        const cid = await uploader.uploadFile(file)
+        const cid = await uploaderActions.uploadFile(file)
         setDataCid(cid)
       } catch (err: any) {
-        console.error(err)
         setError(err)
       } finally {
         setStatus('done')
       }
     }
   }
+
+  const uploaderComponentContextValue = useMemo<UploaderComponentContextValue>(() => [
+    { ...uploaderState, file, dataCid, status, error, handleUploadSubmit },
+    { ...uploaderActions, setFile }
+  ], [uploaderState, file, dataCid, status, error, handleUploadSubmit, uploaderActions, setFile])
+
   return (
-    <UploaderContext.Provider value={{ storedDAGShards, file, setFile, dataCid, status, error, handleUploadSubmit }}>
+    <UploaderComponentContext.Provider value={uploaderComponentContextValue}>
       {children}
-    </UploaderContext.Provider>
+    </UploaderComponentContext.Provider>
   )
 }
 
 Uploader.Input = (props: any) => {
-  const { setFile } = useContext(UploaderContext)
+  const [, { setFile }] = useContext(UploaderComponentContext)
   return (
     <input type='file' onChange={e => setFile(e?.target?.files?.[0])} {...props} />
   )
 }
 
 Uploader.Form = ({ children, ...props }: { children: React.ReactNode } & any) => {
-  const { handleUploadSubmit } = useContext(UploaderContext)
+  const [{ handleUploadSubmit }] = useContext(UploaderComponentContext)
   return (
     <form onSubmit={handleUploadSubmit} {...props}>
       {children}
     </form>
   )
+}
+
+/**
+ * Use the scoped uploader context state from a parent `Uploader`.
+ */
+export function useUploaderComponent(): UploaderComponentContextValue {
+  return useContext(UploaderComponentContext)
 }
 
 export default Uploader

--- a/packages/react-uploader/src/index.ts
+++ b/packages/react-uploader/src/index.ts
@@ -1,2 +1,3 @@
 export { uploadFile, uploadDirectory, Service, CARMetadata } from '@w3ui/uploader-core'
 export * from './providers/Uploader'
+export * from './Uploader'


### PR DESCRIPTION
I think it makes more sense to include these "headless UI" style components in the @w3ui/react-* packages rather than bundling them together in the react-ui package. It feels more intuitive given the naming - if we do want to have the "no UI" style components in a separate package I'd advocate for callling that package `react-uploader-provider` or `react-uploader-api` or something, but given how much code this is and the fact that tree shaking is pretty good, it seems ok to me to bundle them together.

the react-ui package will be reserved for higher level "customizable UI" style components and can now have opinions about the right way to do customization at the top level rather than having two different flavors of customizability in a single package.

@alanshaw @cmunns curious what you think about this - happy to move the uploader back if we decide that's a better structure