### PR TITLE
feat: UploadsList components

### DIFF
--- a/packages/react-ui/src/SimpleUploader.tsx
+++ b/packages/react-ui/src/SimpleUploader.tsx
@@ -1,6 +1,6 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import { CARMetadata } from '@w3ui/uploader-core'
-import Uploader, { UploaderContext } from '@w3ui/react-uploader';
+import { Uploader, useUploaderComponent } from '@w3ui/react-uploader';
 import { Link, Version } from 'multiformats'
 
 
@@ -38,7 +38,7 @@ export const Done = ({ file, dataCid, storedDAGShards }: {file?: File, dataCid?:
 
 
 export const SimpleUploader = () => {
-  const { status, file, error, dataCid, storedDAGShards } = useContext(UploaderContext)
+  const [{ status, file, error, dataCid, storedDAGShards }] = useUploaderComponent()
   return (
     <Uploader>
       {(status === 'uploading') ? (

--- a/packages/react-ui/src/SimpleUploadsList.tsx
+++ b/packages/react-ui/src/SimpleUploadsList.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { UploadsList } from '@w3ui/react-uploads-list';
+
+export const SimpleUploadsList = () => {
+  return (
+    <UploadsList>
+      {([{ data }]) => (
+        <div className='w3-uploads-list'>
+          <nav>
+            <UploadsList.NextButton className="next">
+              Next
+            </UploadsList.NextButton>
+            <UploadsList.ReloadButton className="reload">
+              Reload
+            </UploadsList.ReloadButton>
+          </nav>
+          <table>
+            <thead>
+              <tr>
+                <th>Uploader DID</th>
+                <th>CAR CID</th>
+                <th>Data CID</th>
+                <th>Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data?.map(({ dataCID, carCID, uploaderDID, uploadedAt }) => (
+                <tr key={dataCID}>
+                  <td>{uploaderDID}</td>
+                  <td>{carCID}</td>
+                  <td>{dataCID}</td>
+                  <td>{uploadedAt.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </UploadsList>
+  )
+}
+

--- a/packages/react-uploader/src/Uploader.tsx
+++ b/packages/react-uploader/src/Uploader.tsx
@@ -136,5 +136,3 @@ Uploader.Form = ({ children, ...props }: { children: React.ReactNode } & any) =>
 export function useUploaderComponent(): UploaderComponentContextValue {
   return useContext(UploaderComponentContext)
 }
-
-export default Uploader

--- a/packages/react-uploads-list/src/UploadsList.tsx
+++ b/packages/react-uploads-list/src/UploadsList.tsx
@@ -72,5 +72,3 @@ export function useUploadsListComponent(): UploadsListComponentContextValue {
   return useContext(UploadsListComponentContext)
 }
 
-export default UploadsList
-

--- a/packages/react-uploads-list/src/UploadsList.tsx
+++ b/packages/react-uploads-list/src/UploadsList.tsx
@@ -1,0 +1,76 @@
+import React, { createContext, useContext, useMemo, useCallback } from 'react'
+import { UploadsListContextState, UploadsListContextActions } from '@w3ui/uploads-list-core'
+import { useUploadsList } from './providers/UploadsList'
+
+export type UploadsListComponentContextState = UploadsListContextState & {
+
+}
+
+export type UploadsListComponentContextActions = UploadsListContextActions & {
+
+}
+
+export type UploadsListComponentContextValue = [
+  state: UploadsListComponentContextState,
+  actions: UploadsListContextActions
+]
+
+export const UploadsListComponentContext = createContext<UploadsListComponentContextValue>([
+  {
+    loading: false
+  },
+  {
+    next: async () => { },
+    reload: async () => { }
+  }
+])
+
+export type UploadsListComponentChildrenProps = [
+  state: UploadsListContextState,
+  actions: UploadsListComponentContextActions
+]
+
+export type UploadsListComponentProps = {
+  children?: ({ }: UploadsListComponentChildrenProps) => React.ReactNode,
+}
+
+export const UploadsList = ({ children }: UploadsListComponentProps) => {
+  const [state, actions] = useUploadsList()
+  const contextValue = useMemo<UploadsListComponentChildrenProps>(
+    () => ([state, actions]),
+    [state, actions])
+  return (
+    <UploadsListComponentContext.Provider value={contextValue}>
+      {(typeof children === 'function') ? (
+        children(contextValue)
+      ) : (
+        children
+      )}
+    </UploadsListComponentContext.Provider>
+  )
+}
+
+UploadsList.NextButton = (props: any) => {
+  const [, { next }] = useContext(UploadsListComponentContext)
+  const onClick = useCallback(function onClick(e: React.MouseEvent) {
+    e.preventDefault()
+    next()
+  }, [next])
+  return <button onClick={onClick} {...props} />
+}
+
+UploadsList.ReloadButton = (props: any) => {
+  const [, { reload }] = useContext(UploadsListComponentContext)
+  const onClick = useCallback(function onClick(e: React.MouseEvent) {
+    e.preventDefault()
+    reload()
+  }, [reload])
+  return <button onClick={onClick} {...props} />
+}
+
+export function useUploadsListComponent(): UploadsListComponentContextValue {
+  return useContext(UploadsListComponentContext)
+}
+
+export default UploadsList
+

--- a/packages/react-uploads-list/src/index.ts
+++ b/packages/react-uploads-list/src/index.ts
@@ -1,1 +1,2 @@
 export * from './providers/UploadsList'
+export * from './UploadsList'


### PR DESCRIPTION
first pass at UploadsLists headless components. needs an example in react-ui to prove out

two main questions for reviewers:

1) any thoughts on the API for this component? feel free to pass on evaluating this until I have an example/docs
2) is it worth adding a "prev" function to the UploaderProvider so that we could build out a real basic "paging" component? I don't think we'll be able to add current page/total number of pages controls and indicators without more support from the backend service, but just forward and backward is better than a one way street
3) otoh, should I maybe add an infinite scroll list component to show off what we can do with the current API?

TODO:
- [ ] get feedback on API
- [x] add example in react-ui
- [x] add `prev` upstream to allow us to build basic pager component (added #143 for this)
- [x] add infinite scroll list subcomponent (added #144 for this)

