### PR TITLE
fix: run babel on .js files as well as .ts

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -30,7 +30,7 @@ const umdDevPlugin = (type: 'development' | 'production'): Plugin =>
 const babelPlugin = babel({
   babelHelpers: 'bundled',
   exclude: /node_modules/,
-  extensions: ['.ts', '.tsx']
+  extensions: ['.ts', '.tsx', '.js']
 })
 
 export default function rollup (options: RollupOptions): RollupOptions[] {


### PR DESCRIPTION
This adds `.js` to the set of file extensions processed by babel.

I'm hoping that this will fix #160, since after running `npm run build` with this change I no longer see any class private members in `packages/react-keyring/build/esm/index.js`, which is where the example was failing before.

The downside of this change is that the rolled-up `index.js` grew from 198kb to 300kb for react-keyring. I assume the other modules are affected as well.

I also haven't been able to test this in codesandbox, since I don't know how to make it depend on an unreleased npm package (or if that's even possible).

