### PR TITLE
Fix docs link from react-uploads-list to keyring page

### DIFF
--- a/docs/react-uploads-list.md
+++ b/docs/react-uploads-list.md
@@ -21,7 +21,7 @@ import * as ReactUploadsList from '@w3ui/react-uploads-list'
 
 ### `UploadsListProvider`
 
-Provider for a list of items uploaded by the current agent. Note that this provider uses [`useKeyring`](./react-keyring#usekeyring) to obtain the current agent's identity.
+Provider for a list of items uploaded by the current agent. Note that this provider uses [`useKeyring`](./react-keyring.md#usekeyring) to obtain the current agent's identity.
 
 Example:
 


### PR DESCRIPTION
(this PR replaces https://github.com/web3-storage/w3ui/pull/151 which was against a now-obsolete branch)


At least in certain contexts (specifically I was viewing from the URL <https://github.com/web3-storage/w3ui/blob/w3ui/docs/react-uploads-list.md> via the `next` branch) the useKeyring documentation link led to a 404 when clicked. Adding the `.md` extension seems to be all that's needed.