### PR TITLE
fix: get solid examples working again

### DIFF
--- a/examples/solid/uploads-list/src/ContentPage.jsx
+++ b/examples/solid/uploads-list/src/ContentPage.jsx
@@ -15,23 +15,19 @@ export function ContentPage () {
           <Errored error={data.error} />
         </Match>
         <Match when={data.state === 'ready'}>
-          {data().results.length
+          { data().results.length
             ? (
               <div className='overflow-auto'>
                 <table className='w-100 mb3 collapse'>
                   <thead className='near-white tl'>
                     <tr>
                       <th className='pa3'>Data CID</th>
-                      <th className='pa3'>CAR CID</th>
-                      <th className='pa3'>Date</th>
                     </tr>
                   </thead>
                   <tbody>
-                    {data().results.map(({ dataCid, carCids, uploadedAt }) => (
-                      <tr key={dataCid} className='stripe-light'>
-                        <td className='pa3'>{dataCid}</td>
-                        <td className='pa3'>{carCids[0]}</td>
-                        <td className='pa3'>{uploadedAt.toLocaleString()}</td>
+                    {data().results.map(({ root }) => (
+                      <tr key={root.toString()} className='stripe-light'>
+                        <td className='pa3'>{root.toString()}</td>
                       </tr>
                     ))}
                   </tbody>

--- a/examples/solid/uploads-list/src/ContentPage.jsx
+++ b/examples/solid/uploads-list/src/ContentPage.jsx
@@ -15,7 +15,7 @@ export function ContentPage () {
           <Errored error={data.error} />
         </Match>
         <Match when={data.state === 'ready'}>
-          { data().results.length
+          {data().results.length
             ? (
               <div className='overflow-auto'>
                 <table className='w-100 mb3 collapse'>

--- a/packages/solid-keyring/package.json
+++ b/packages/solid-keyring/package.json
@@ -24,14 +24,14 @@
   },
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/solid-keyring",
   "dependencies": {
-    "@w3ui/keyring-core": "^2.0.1"
+    "@w3ui/keyring-core": "^2.0.1",
+    "@ucanto/interface": "^4.0.3",
+    "@ucanto/principal": "^4.0.3",
+    "@web3-storage/access": "^9.2.0"
   },
   "peerDependencies": {
     "solid-js": "^1.5.0"
   },
   "devDependencies": {
-    "@ucanto/interface": "^4.0.3",
-    "@ucanto/principal": "^4.0.3",
-    "@web3-storage/access": "^9.2.0"
   }
 }

--- a/packages/solid-keyring/src/providers/Keyring.ts
+++ b/packages/solid-keyring/src/providers/Keyring.ts
@@ -1,8 +1,11 @@
-import { createContext, useContext, createSignal, createComponent, ParentComponent } from 'solid-js'
-import { createStore } from 'solid-js/store'
-import { createAgent, getCurrentSpace, getSpaces, KeyringContextState, KeyringContextActions, ServiceConfig } from '@w3ui/keyring-core'
+import type { ParentComponent }from 'solid-js'
+import type { KeyringContextState, KeyringContextActions, ServiceConfig } from '@w3ui/keyring-core'
 import type { Agent } from '@web3-storage/access'
 import type { Delegation, Capability, DID } from '@ucanto/interface'
+
+import { createContext, useContext, createSignal, createComponent } from 'solid-js'
+import { createStore } from 'solid-js/store'
+import { createAgent, getCurrentSpace, getSpaces, } from '@w3ui/keyring-core'
 
 export { KeyringContextState, KeyringContextActions }
 

--- a/packages/solid-keyring/src/providers/Keyring.ts
+++ b/packages/solid-keyring/src/providers/Keyring.ts
@@ -1,11 +1,11 @@
-import type { ParentComponent }from 'solid-js'
+import type { ParentComponent } from 'solid-js'
 import type { KeyringContextState, KeyringContextActions, ServiceConfig } from '@w3ui/keyring-core'
 import type { Agent } from '@web3-storage/access'
 import type { Delegation, Capability, DID } from '@ucanto/interface'
 
 import { createContext, useContext, createSignal, createComponent } from 'solid-js'
 import { createStore } from 'solid-js/store'
-import { createAgent, getCurrentSpace, getSpaces, } from '@w3ui/keyring-core'
+import { createAgent, getCurrentSpace, getSpaces } from '@w3ui/keyring-core'
 
 export { KeyringContextState, KeyringContextActions }
 

--- a/packages/solid-uploader/package.json
+++ b/packages/solid-uploader/package.json
@@ -24,12 +24,12 @@
   },
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/solid-uploader",
   "dependencies": {
+    "@w3ui/solid-keyring": "^2.0.0",
     "@w3ui/uploader-core": "^3.0.1",
     "@web3-storage/capabilities": "^2.0.0",
     "multiformats": "^10.0.2"
   },
   "peerDependencies": {
-    "@w3ui/solid-keyring": "^2.0.0",
     "solid-js": "^1.5.0"
   }
 }

--- a/packages/solid-uploader/src/index.ts
+++ b/packages/solid-uploader/src/index.ts
@@ -1,2 +1,3 @@
-export { uploadFile, uploadDirectory, Service, CARMetadata } from '@w3ui/uploader-core'
+export { uploadFile, uploadDirectory } from '@w3ui/uploader-core'
+export type { Service, CARMetadata } from '@w3ui/uploader-core'
 export * from './providers/Uploader'

--- a/packages/solid-uploads-list/src/resources/UploadsList.ts
+++ b/packages/solid-uploads-list/src/resources/UploadsList.ts
@@ -1,7 +1,10 @@
-import { createResource, InitializedResourceReturn, ResourceOptions, ResourceReturn, ResourceSource } from 'solid-js'
+import type { InitializedResourceReturn, ResourceOptions, ResourceReturn, ResourceSource } from 'solid-js'
 import type { Space } from '@w3ui/keyring-core'
-import { list, ServiceConfig, ListResponse, UploadListResult } from '@w3ui/uploads-list-core'
+import type { ServiceConfig, ListResponse, UploadListResult } from '@w3ui/uploads-list-core'
 import type { Capability, Proof, Signer } from '@ucanto/interface'
+
+import { createResource } from 'solid-js'
+import { list } from '@w3ui/uploads-list-core'
 import { list as uploadList } from '@web3-storage/capabilities/upload'
 
 interface UploadsListSource extends ServiceConfig {


### PR DESCRIPTION
vite is more particular about type imports and peer vs dev vs regular dependencies - these fixes all help make the solid examples work properly

frustratingly, something still seems off about the way vite is trying to load the umd build - these changes work on my pnpm branch but still fail here. code examples should be helpful for folks trying to build, but it may still be tricky to get these examples working until we move to pnpm