### PR TITLE
feat: test examples in playwright

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,4 @@
 {
-  "buildCommand": false,
   "sandboxes": [
     "/examples/react/file-upload",
     "/examples/react/sign-up-in",

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,5 @@
 {
+  "buildCommand": false,
   "sandboxes": [
     "/examples/react/file-upload",
     "/examples/react/sign-up-in",

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -4,12 +4,12 @@ on:
     branches:
       - main
     paths:
-      - "examples"
+      - "examples/**"
   pull_request:
     branches:
       - main
     paths:
-      - "examples"
+      - "examples/**"
 jobs:
   test:
     name: Browser test

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -1,0 +1,35 @@
+name: Examples
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "examples"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "examples"
+jobs:
+  test:
+    name: Browser test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ./.github/actions/test
+
+      - name: Install Playwright Browsers
+        run: pnpx playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: pnpx playwright test
+        working-directory: examples/vue/sign-in-up
+
+      # save test report
+      # - uses: actions/upload-artifact@v3
+      #   if: always()
+      #   with:
+      #     name: playwright-report
+      #     path: playwright-report/
+      #     retention-days: 30

--- a/examples/vue/sign-up-in/.gitignore
+++ b/examples/vue/sign-up-in/.gitignore
@@ -26,3 +26,6 @@ coverage
 *.njsproj
 *.sln
 *.sw?
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/examples/vue/sign-up-in/package.json
+++ b/examples/vue/sign-up-in/package.json
@@ -4,14 +4,18 @@
   "scripts": {
     "start": "vite",
     "dev": "vite",
+    "test": "playwright test",
+    "playwright": "playwright test",
     "build": "vite build",
     "preview": "vite preview --port 4173"
   },
   "dependencies": {
     "@w3ui/vue-keyring": "workspace:^",
+    "playwright": "^1.29.2",
     "vue": "^3.2.38"
   },
   "devDependencies": {
+    "@playwright/test": "^1.29.2",
     "@vitejs/plugin-vue": "^3.0.3",
     "vite": "^3.0.9"
   }

--- a/examples/vue/sign-up-in/package.json
+++ b/examples/vue/sign-up-in/package.json
@@ -11,10 +11,10 @@
   },
   "dependencies": {
     "@w3ui/vue-keyring": "workspace:^",
-    "playwright": "^1.29.2",
     "vue": "^3.2.38"
   },
   "devDependencies": {
+    "playwright": "^1.29.2",
     "@playwright/test": "^1.29.2",
     "@vitejs/plugin-vue": "^3.0.3",
     "vite": "^3.0.9"

--- a/examples/vue/sign-up-in/playwright.config.ts
+++ b/examples/vue/sign-up-in/playwright.config.ts
@@ -1,5 +1,5 @@
-import type { PlaywrightTestConfig } from '@playwright/test';
-import { devices } from '@playwright/test';
+import type { PlaywrightTestConfig } from '@playwright/test'
+import { devices } from '@playwright/test'
 
 /**
  * Read environment variables from file.
@@ -24,11 +24,11 @@ const config: PlaywrightTestConfig = {
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
+  forbidOnly: !!process.env.CI, // eslint-disable-line @typescript-eslint/strict-boolean-expressions
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 2 : 0, // eslint-disable-line @typescript-eslint/strict-boolean-expressions
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 1 : undefined, // eslint-disable-line @typescript-eslint/strict-boolean-expressions
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -39,13 +39,13 @@ const config: PlaywrightTestConfig = {
     baseURL: 'http://localhost:1337',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: 'on-first-retry'
   },
 
   /* Run your local dev server before starting the tests */
   webServer: {
     command: 'pnpm start --port 1337',
-    port: 1337,
+    port: 1337
   },
 
   /* Configure projects for major browsers */
@@ -53,23 +53,23 @@ const config: PlaywrightTestConfig = {
     {
       name: 'chromium',
       use: {
-        ...devices['Desktop Chrome'],
-      },
+        ...devices['Desktop Chrome']
+      }
     },
 
     {
       name: 'firefox',
       use: {
-        ...devices['Desktop Firefox'],
-      },
+        ...devices['Desktop Firefox']
+      }
     },
 
     {
       name: 'webkit',
       use: {
-        ...devices['Desktop Safari'],
-      },
-    },
+        ...devices['Desktop Safari']
+      }
+    }
 
     /* Test against mobile viewports. */
     // {
@@ -98,10 +98,10 @@ const config: PlaywrightTestConfig = {
     //     channel: 'chrome',
     //   },
     // },
-  ],
+  ]
 
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */
   // outputDir: 'test-results/',
-};
+}
 
-export default config;
+export default config

--- a/examples/vue/sign-up-in/playwright.config.ts
+++ b/examples/vue/sign-up-in/playwright.config.ts
@@ -1,0 +1,107 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+import { devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+const config: PlaywrightTestConfig = {
+  testDir: './tests',
+  /* Maximum time one test can run for. */
+  timeout: 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://localhost:1337',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'pnpm start --port 1337',
+    port: 1337,
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+      },
+    },
+
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari'],
+      },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: {
+    //     ...devices['Pixel 5'],
+    //   },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: {
+    //     ...devices['iPhone 12'],
+    //   },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: {
+    //     channel: 'msedge',
+    //   },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: {
+    //     channel: 'chrome',
+    //   },
+    // },
+  ],
+
+  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+  // outputDir: 'test-results/',
+};
+
+export default config;

--- a/examples/vue/sign-up-in/tests/e2e.spec.ts
+++ b/examples/vue/sign-up-in/tests/e2e.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test'
+
+test('get started link', async ({ page }) => {
+  await page.goto('/')
+
+  await expect(page).toHaveTitle('W3UI Sign Up / In Example App')
+
+  const input = page.getByRole('textbox', { name: 'Email address:' })
+  await input.fill('test@example.org')
+  await input.press('Enter')
+
+  // Test that the form worked
+  await expect(page.getByText('Verify your email address!')).toBeVisible()
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,14 +311,18 @@ importers:
 
   examples/vue/sign-up-in:
     specifiers:
+      '@playwright/test': ^1.29.2
       '@vitejs/plugin-vue': ^3.0.3
       '@w3ui/vue-keyring': workspace:^
+      playwright: ^1.29.2
       vite: ^3.0.9
       vue: ^3.2.38
     dependencies:
       '@w3ui/vue-keyring': link:../../../packages/vue-keyring
+      playwright: 1.29.2
       vue: 3.2.45
     devDependencies:
+      '@playwright/test': 1.29.2
       '@vitejs/plugin-vue': 3.2.0_vite@3.2.5+vue@3.2.45
       vite: 3.2.5
 
@@ -2188,6 +2192,15 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.14.0
+    dev: true
+
+  /@playwright/test/1.29.2:
+    resolution: {integrity: sha512-+3/GPwOgcoF0xLz/opTnahel1/y42PdcgZ4hs+BZGIUjtmEFSXGg+nFoaH3NSmuc7a6GSFwXDJ5L7VXpqzigNg==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dependencies:
+      '@types/node': 18.11.17
+      playwright-core: 1.29.2
     dev: true
 
   /@protobufjs/aspromise/1.1.2:
@@ -5926,6 +5939,20 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       find-up: 3.0.0
+
+  /playwright-core/1.29.2:
+    resolution: {integrity: sha512-94QXm4PMgFoHAhlCuoWyaBYKb92yOcGVHdQLoxQ7Wjlc7Flg4aC/jbFW7xMR52OfXMVkWicue4WXE7QEegbIRA==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  /playwright/1.29.2:
+    resolution: {integrity: sha512-hKBYJUtdmYzcjdhYDkP9WGtORwwZBBKAW8+Lz7sr0ZMxtJr04ASXVzH5eBWtDkdb0c3LLFsehfPBTRfvlfKJOA==}
+    engines: {node: '>=14'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      playwright-core: 1.29.2
+    dev: false
 
   /plur/5.1.0:
     resolution: {integrity: sha512-VP/72JeXqak2KiOzjgKtQen5y3IZHn+9GOuLDafPv0eXa47xq0At93XahYBs26MsifCQ4enGKwbjBTKgb9QJXg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,11 +319,11 @@ importers:
       vue: ^3.2.38
     dependencies:
       '@w3ui/vue-keyring': link:../../../packages/vue-keyring
-      playwright: 1.29.2
       vue: 3.2.45
     devDependencies:
       '@playwright/test': 1.29.2
       '@vitejs/plugin-vue': 3.2.0_vite@3.2.5+vue@3.2.45
+      playwright: 1.29.2
       vite: 3.2.5
 
   examples/vue/template:
@@ -5944,6 +5944,7 @@ packages:
     resolution: {integrity: sha512-94QXm4PMgFoHAhlCuoWyaBYKb92yOcGVHdQLoxQ7Wjlc7Flg4aC/jbFW7xMR52OfXMVkWicue4WXE7QEegbIRA==}
     engines: {node: '>=14'}
     hasBin: true
+    dev: true
 
   /playwright/1.29.2:
     resolution: {integrity: sha512-hKBYJUtdmYzcjdhYDkP9WGtORwwZBBKAW8+Lz7sr0ZMxtJr04ASXVzH5eBWtDkdb0c3LLFsehfPBTRfvlfKJOA==}
@@ -5952,7 +5953,7 @@ packages:
     requiresBuild: true
     dependencies:
       playwright-core: 1.29.2
-    dev: false
+    dev: true
 
   /plur/5.1.0:
     resolution: {integrity: sha512-VP/72JeXqak2KiOzjgKtQen5y3IZHn+9GOuLDafPv0eXa47xq0At93XahYBs26MsifCQ4enGKwbjBTKgb9QJXg==}


### PR DESCRIPTION
- use playwright and playwright-test to verify the examples run in a browser
- have playwright-test fire up the vite preview server on a known port to serve the example
- add github workflow

So far i've just added a minimal e2e style test for the vue sign-in-up example, to show the pattern and get feedback. It's already found a bug there in safari which doesn't appear in firefox or chrome:

<img width="839" alt="Screenshot 2023-01-09 at 14 30 39" src="https://user-images.githubusercontent.com/58871/211332355-b7af43b7-d13b-44e8-8895-2cbe01374ddf.png">

<img width="839" alt="Screenshot 2023-01-09 at 14 30 53" src="https://user-images.githubusercontent.com/58871/211332376-b0a21d21-6a65-4f48-a072-a5049cf3b741.png">

WIP on #150 

### TODO

- add tests for other examples
- consider pulling tests up to parent dir and reuse the same e2e test for each ui flavour - i'm imagining we'd have a test for each example, and then run that suite once for each ui library directory.
- fix safari bug in sign-in example where submitting the form errors and returns the user to the form instead of the verify message

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>