### PR TITLE
feat: use css variable-based styles to enable customization

### DIFF
--- a/examples/react/ui/src/ContentPage.jsx
+++ b/examples/react/ui/src/ContentPage.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { SimpleUploadsList, SimpleUploader, W3Upload } from '@w3ui/react-ui'
+import '@w3ui/react-ui/src/styles/uploader.css'
 import { Uploader, UploaderProvider, useUploader } from '@w3ui/react-uploader'
 import { UploadsListProvider } from '@w3ui/react-uploads-list'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'

--- a/packages/react-ui/src/SimpleUploader.tsx
+++ b/packages/react-ui/src/SimpleUploader.tsx
@@ -47,7 +47,7 @@ export const Done = ({ file, dataCID, storedDAGShards }: DoneProps): JSX.Element
 export const SimpleUploader = (): JSX.Element => {
   const [{ status, file, error, dataCID, storedDAGShards }] = useUploaderComponent()
   return (
-    <Uploader>
+    <Uploader as='div' className='w3ui-uploader-wrapper'>
       {(status === Status.Uploading)
         ? (
           <Uploading file={file} storedDAGShards={storedDAGShards} />
@@ -62,12 +62,12 @@ export const SimpleUploader = (): JSX.Element => {
                     <Errored error={error} />
                     )
                   : (
-                    <Uploader.Form className=''>
-                      <div className='field'>
-                        <label htmlFor='w3ui-uploader-file'>File:</label>
-                        <Uploader.Input id='w3ui-uploader-file' />
+                    <Uploader.Form>
+                      <div className='w3ui-uploader'>
+                        <label className='w3ui-uploader__label'>File:</label>
+                        <Uploader.Input className='w3ui-uploader__input' />
                       </div>
-                      <button type='submit'>Upload</button>
+                      <button type='submit' className='w3ui-button'>Upload</button>
                     </Uploader.Form>
                     )
           )}

--- a/packages/react-ui/src/styles/uploader.css
+++ b/packages/react-ui/src/styles/uploader.css
@@ -1,0 +1,85 @@
+:root {
+  --w3ui-uploader-padding: 2rem;
+  --w3ui-uploader-background: rgba(255, 255, 255, 0.05);
+  --w3ui-uploader-background-hover: rgba(255, 255, 255, 0.08);
+  --w3ui-uploader-height: 250px;
+  --w3ui-uploader-border-color: rgba(255, 255, 255, 0.25);
+  --w3ui-uploader-border-radius: 8px;
+  --w3ui-uploader-primary: salmon;
+  --w3ui-uploader-primary-hover: rgb(250, 136, 124);
+}
+
+.w3ui-uploader {
+  position: relative;
+  height: var(--w3ui-uploader-height);
+  padding: var(--w3ui-uploader-padding);
+  color: var(--w3ui-uploader-border);
+  border-radius: var(--w3ui-uploader-border-radius);
+  border: 2px dashed var(--w3ui-uploader-border-color);
+  background-color: var(--w3ui-uploader-background);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25em;
+  transition: all 0.25s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.w3ui-uploader:hover {
+  background-color: var(--w3ui-uploader-background-hover);
+}
+
+.w3ui-uploader:before {
+  background-color: var(--w3ui-uploader-border-color);
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 14 14' height='16' width='16'%3E%3Cpath stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' d='M7.36356 5.93196V11.932'%3E%3C/path%3E%3Cpath stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' d='M5.36356 7.93196L7.36356 5.93196L9.36356 7.93196'%3E%3C/path%3E%3Cpath stroke='currentColor' stroke-linecap='round' d='M3.91963 9.6519C3.0748 9.70862 2.24205 9.42742 1.60455 8.87014C0.967062 8.31287 0.577055 7.52518 0.520331 6.68036C0.463607 5.83553 0.744812 5.00277 1.30208 4.36528C1.57802 4.04963 1.91342 3.79141 2.28915 3.60538C2.66487 3.41935 3.07356 3.30915 3.49187 3.28106C3.53529 3.28201 3.57806 3.27052 3.61516 3.24794C3.65225 3.22536 3.68211 3.19264 3.7012 3.15364C3.98977 2.31728 4.55635 1.60512 5.30644 1.13593C6.05653 0.666737 6.94481 0.468875 7.82313 0.575338C8.70145 0.681801 9.51672 1.08615 10.133 1.72096C10.7493 2.35578 11.1293 3.18267 11.2097 4.06376C11.2164 4.11015 11.2363 4.15365 11.2669 4.18913C11.2975 4.22461 11.3377 4.25058 11.3826 4.26399C12.033 4.41721 12.6046 4.80358 12.9892 5.34994C13.3738 5.8963 13.5447 6.56472 13.4695 7.22864C13.3944 7.89255 13.0784 8.50587 12.5814 8.95246C12.0845 9.39904 11.441 9.6479 10.7728 9.6519'%3E%3C/path%3E%3C/svg%3E");
+  mask-repeat: no-repeat;
+  mask-size: 1.6rem;
+  mask-position: top center;
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 14 14' height='16' width='16'%3E%3Cpath stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' d='M7.36356 5.93196V11.932'%3E%3C/path%3E%3Cpath stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' d='M5.36356 7.93196L7.36356 5.93196L9.36356 7.93196'%3E%3C/path%3E%3Cpath stroke='currentColor' stroke-linecap='round' d='M3.91963 9.6519C3.0748 9.70862 2.24205 9.42742 1.60455 8.87014C0.967062 8.31287 0.577055 7.52518 0.520331 6.68036C0.463607 5.83553 0.744812 5.00277 1.30208 4.36528C1.57802 4.04963 1.91342 3.79141 2.28915 3.60538C2.66487 3.41935 3.07356 3.30915 3.49187 3.28106C3.53529 3.28201 3.57806 3.27052 3.61516 3.24794C3.65225 3.22536 3.68211 3.19264 3.7012 3.15364C3.98977 2.31728 4.55635 1.60512 5.30644 1.13593C6.05653 0.666737 6.94481 0.468875 7.82313 0.575338C8.70145 0.681801 9.51672 1.08615 10.133 1.72096C10.7493 2.35578 11.1293 3.18267 11.2097 4.06376C11.2164 4.11015 11.2363 4.15365 11.2669 4.18913C11.2975 4.22461 11.3377 4.25058 11.3826 4.26399C12.033 4.41721 12.6046 4.80358 12.9892 5.34994C13.3738 5.8963 13.5447 6.56472 13.4695 7.22864C13.3944 7.89255 13.0784 8.50587 12.5814 8.95246C12.0845 9.39904 11.441 9.6479 10.7728 9.6519'%3E%3C/path%3E%3C/svg%3E");
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-size: 1.6rem;
+  -webkit-mask-position: top center;
+  padding-top: 1rem;
+  content: "Upload";
+}
+
+.w3ui-uploader:after {
+  content: "Drag files or Click to Browse";
+  /* color: var(--w3ui-uploader-primary); */
+}
+
+.w3ui-uploader__label {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.w3ui-uploader__input {
+  cursor: pointer;
+  position: absolute;
+  padding: 0;
+  opacity: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+.w3ui-button {
+  width: 100%;
+  background-color: var(--w3ui-uploader-primary);
+  border-radius: var(--w3ui-uploader-border-radius);
+  outline: none;
+  border: 0;
+  padding: 0.75em;
+  cursor: pointer;
+  transition: all 0.25s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.w3ui-button:hover {
+  background-color: var(--w3ui-uploader-primary-hover);
+}


### PR DESCRIPTION
Use @cmunns's styles from #140 to enable css-variable-based customizable styling of SimpleUploader.

Demonstrate how this can be used with a default stylesheet we provide to get great looking components out of the box.

<img width="650" alt="Screen Shot 2023-01-10 at 5 19 02 PM" src="https://user-images.githubusercontent.com/1113/211695920-5193dace-a26c-44d8-8c3f-2e29bab10325.png">
