### PR TITLE
fix: load first page of uploads list in provider

### DIFF
--- a/packages/react-uploads-list/src/UploadsList.tsx
+++ b/packages/react-uploads-list/src/UploadsList.tsx
@@ -1,7 +1,7 @@
 import type { As, Component, Props, Options, RenderProp } from 'ariakit-react-utils'
 import type { UploadsListContextState, UploadsListContextActions } from '@w3ui/uploads-list-core'
 
-import React, { Fragment, createContext, useContext, useMemo, useCallback, useEffect } from 'react'
+import React, { Fragment, createContext, useContext, useMemo, useCallback } from 'react'
 import { createComponent, createElement } from 'ariakit-react-utils'
 import { useUploadsList } from './providers/UploadsList'
 

--- a/packages/react-uploads-list/src/UploadsList.tsx
+++ b/packages/react-uploads-list/src/UploadsList.tsx
@@ -68,10 +68,6 @@ export const UploadsListRoot = (props: UploadsListRootProps): JSX.Element => {
   } else {
     renderedChildren = children as React.ReactNode
   }
-  useEffect(() => {
-    // load the first page of results asynchronously
-    void actions.next()
-  }, [])
   return (
     <UploadsListComponentContext.Provider value={contextValue}>
       {renderedChildren}

--- a/packages/react-uploads-list/src/providers/UploadsList.tsx
+++ b/packages/react-uploads-list/src/providers/UploadsList.tsx
@@ -13,8 +13,8 @@ export const uploadsListContextDefaultValue: UploadsListContextValue = [
     loading: false
   },
   {
-    next: async () => { },
-    reload: async () => { }
+    next: async () => {},
+    reload: async () => {}
   }
 ]
 
@@ -82,6 +82,9 @@ export function UploadsListProvider ({ size, servicePrincipal, connection, child
     }
   }
 
+  // we should reload the page any time the space or agent change
+  useEffect(() => { void loadPage() }, [space, agent])
+
   return (
     <UploadsListContext.Provider value={[state, actions]}>
       {children}
@@ -93,8 +96,5 @@ export function UploadsListProvider ({ size, servicePrincipal, connection, child
  * Use the scoped uploads list context state from a parent `UploadsListProvider`.
 */
 export function useUploadsList (): UploadsListContextValue {
-  const ctx = useContext(UploadsListContext)
-  // automatically load the first page of results
-  useEffect(() => { void ctx[1].next() }, [])
-  return ctx
+  return useContext(UploadsListContext)
 }

--- a/packages/react-uploads-list/src/providers/UploadsList.tsx
+++ b/packages/react-uploads-list/src/providers/UploadsList.tsx
@@ -95,6 +95,6 @@ export function UploadsListProvider ({ size, servicePrincipal, connection, child
 export function useUploadsList (): UploadsListContextValue {
   const ctx = useContext(UploadsListContext)
   // automatically load the first page of results
-  useEffect(() => { ctx[1].next() }, [])
+  useEffect(() => { void ctx[1].next() }, [])
   return ctx
 }

--- a/packages/react-uploads-list/src/providers/UploadsList.tsx
+++ b/packages/react-uploads-list/src/providers/UploadsList.tsx
@@ -94,7 +94,7 @@ export function UploadsListProvider ({ size, servicePrincipal, connection, child
 
 /**
  * Use the scoped uploads list context state from a parent `UploadsListProvider`.
-*/
+ */
 export function useUploadsList (): UploadsListContextValue {
   return useContext(UploadsListContext)
 }

--- a/packages/react-uploads-list/src/providers/UploadsList.tsx
+++ b/packages/react-uploads-list/src/providers/UploadsList.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, createContext, useState } from 'react'
+import React, { useContext, createContext, useState, useEffect } from 'react'
 import { UploadListResult, UploadsListContextState, UploadsListContextActions, ServiceConfig, list } from '@w3ui/uploads-list-core'
 import { useKeyring } from '@w3ui/react-keyring'
 import { list as uploadList } from '@web3-storage/capabilities/upload'
@@ -13,8 +13,8 @@ export const uploadsListContextDefaultValue: UploadsListContextValue = [
     loading: false
   },
   {
-    next: async () => {},
-    reload: async () => {}
+    next: async () => { },
+    reload: async () => { }
   }
 ]
 
@@ -72,6 +72,8 @@ export function UploadsListProvider ({ size, servicePrincipal, connection, child
       setLoading(false)
     }
   }
+  // automatically load the first page of results
+  useEffect(() => { void loadPage() }, [])
 
   const state = { data, loading, error }
   const actions = {

--- a/packages/react-uploads-list/src/providers/UploadsList.tsx
+++ b/packages/react-uploads-list/src/providers/UploadsList.tsx
@@ -72,8 +72,6 @@ export function UploadsListProvider ({ size, servicePrincipal, connection, child
       setLoading(false)
     }
   }
-  // automatically load the first page of results
-  useEffect(() => { void loadPage() }, [])
 
   const state = { data, loading, error }
   const actions = {
@@ -93,7 +91,10 @@ export function UploadsListProvider ({ size, servicePrincipal, connection, child
 
 /**
  * Use the scoped uploads list context state from a parent `UploadsListProvider`.
- */
+*/
 export function useUploadsList (): UploadsListContextValue {
-  return useContext(UploadsListContext)
+  const ctx = useContext(UploadsListContext)
+  // automatically load the first page of results
+  useEffect(() => { ctx[1].next() }, [])
+  return ctx
 }


### PR DESCRIPTION
rather than doing this in the headless component, do it in the hook so that hook users also get a page of results. originally had this in the provider but that had timing issues and only worked sometimes.