### PR TITLE
chore: get codesandbox examples working again

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,5 @@
 {
+  "buildCommand": false,
   "sandboxes": [
     "/examples/react/file-upload",
     "/examples/react/sign-up-in",
@@ -11,5 +12,5 @@
     "/examples/vue/uploads-list"
   ],
   "packages": ["packages/**"],
-  "node": "16"
+  "node": "18"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,4 @@
 {
-  "installCommand": "codesandbox:install",
   "buildCommand": false,
   "sandboxes": [
     "/examples/react/file-upload",

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,5 @@
 {
+  "installCommand": "codesandbox:install",
   "buildCommand": false,
   "sandboxes": [
     "/examples/react/file-upload",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "typecheck": "tsc -b",
     "test:examples": "pnpm run --filter './examples/**' test",
     "build:examples": "pnpm run --filter './examples/**' --no-bail build || true",
-    "serve:examples": "serve examples"
+    "serve:examples": "serve examples",
+    "codesandbox:install": "npx pnpm install --frozen-lockfile, --strict-peer-dependencies"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "typecheck": "tsc -b",
     "test:examples": "pnpm run --filter './examples/**' test",
     "build:examples": "pnpm run --filter './examples/**' --no-bail build || true",
-    "serve:examples": "serve examples",
-    "codesandbox:install": "npx pnpm install --frozen-lockfile, --strict-peer-dependencies"
+    "serve:examples": "serve examples"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",


### PR DESCRIPTION
- codesansbox ci now support node 18
- disable `buildCommand` as it is done after install by the prepare lifecycle script

see: https://codesandbox.io/docs/learn/sandboxes/ci#configuration-format

fixes #237

note: there is an issue to consolidate the examples in #256 but our current set of examples are linked to from beta.ui.web3.storage so if we can get them working again without too much pain I think we should.

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>