### PR TITLE
fix: install correct browser versions for playwright tests

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm
       - run: pnpm build:examples
-      - run: pnpm playwright:install --with-deps  # install browsers
+      - run: pnpm playwright:install --with-deps # install browsers
       - run: pnpm test:examples
 
       # save test report

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -18,8 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm
       - run: pnpm build:examples
-      - run: pnpm exec playwright install install --with-deps # install browsers
-        working-directory: examples/test/playwright           # ensure same version of playwright is used so we get the browser versions that the tests expect
+      - run: pnpm playwright:install --with-deps  # install browsers
       - run: pnpm test:examples
 
       # save test report

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -18,7 +18,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm
       - run: pnpm build:examples
-      - run: pnpx playwright install --with-deps # install browsers
+      - run: pnpm exec playwright install install --with-deps # install browsers
+        working-directory: examples/test/playwright           # ensure same version of playwright is used so we get the browser versions that the tests expect
       - run: pnpm test:examples
 
       # save test report

--- a/examples/test/playwright/README.md
+++ b/examples/test/playwright/README.md
@@ -11,7 +11,7 @@ Install the deps and the browsers from the root of the monorepo
 $ pnpm i
 
 # fetch test browsers
-$ pnpx playwright install
+$ pnpm playwright:install
 ```
 
 Build the examples to their many dist folders

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "typecheck": "tsc -b",
     "test:examples": "pnpm run --filter './examples/**' test",
     "build:examples": "pnpm run --filter './examples/**' --no-bail build || true",
-    "serve:examples": "serve examples"
+    "serve:examples": "serve examples",
+    "playwright:install": "pnpm --filter './examples/test/playwright' exec playwright install"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",


### PR DESCRIPTION
by running pnpm exec playwright install from the playwright dir, pnpm knows to use the version of playwright that we depend on rather than the latest version.

without this change we end up installing the latest browesers and then the tests fail as they can't find the older versions that they assume will have been installed.

...and it turns out `pnpx` is deprecated, and we should be using `pnpm exec` anyway.

fixes: https://github.com/web3-storage/w3ui/issues/297

see: https://pnpm.io/6.x/cli/exec

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>