### PR TITLE
fix: fix w3console styling

### DIFF
--- a/examples/react/w3console/src/app.tsx
+++ b/examples/react/w3console/src/app.tsx
@@ -7,9 +7,7 @@ import { useKeyring } from '@w3ui/react-keyring'
 import { useUploadsList } from '@w3ui/react-uploads-list'
 import { ShareIcon } from '@heroicons/react/20/solid'
 import md5 from 'blueimp-md5'
-import '@w3ui/react/src/styles/uploader.css'
-import '@w3ui/react/src/styles/space-finder.css'
-import '@w3ui/react/src/styles/uploads-list.css'
+import '@w3ui/react/src/styles/all.css'
 import { SpaceShare } from './share'
 
 function SpaceRegistrar (): JSX.Element {

--- a/packages/react/src/Authenticator.tsx
+++ b/packages/react/src/Authenticator.tsx
@@ -41,9 +41,14 @@ export function AuthenticationEnsurer ({ children }: { children: JSX.Element | J
   }
 }
 
-export function Authenticator ({ children }: { children: JSX.Element | JSX.Element[] }): JSX.Element {
+interface AuthenticatorProps {
+  children: JSX.Element | JSX.Element[]
+  className?: string
+}
+
+export function Authenticator ({ children, className = '' }: AuthenticatorProps): JSX.Element {
   return (
-    <AuthCore as='div' className='w3ui-authenticator'>
+    <AuthCore as='div' className={`w3ui-authenticator ${className}`}>
       <AuthenticationEnsurer>
         {children}
       </AuthenticationEnsurer>

--- a/packages/react/src/styles/all.css
+++ b/packages/react/src/styles/all.css
@@ -1,0 +1,5 @@
+@import url(authenticator.css);
+@import url(space-creator.css);
+@import url(space-finder.css);
+@import url(uploader.css);
+@import url(uploads-list.css);


### PR DESCRIPTION
I broke the w3console styling by failing to include some of the new stylesheets from the react components. Fix that, and introduce an omnibus CSS file called `all.css` to make this easier in the future.

Also tweak the Authenticator component to accept a top-level CSS class - I didn't end up using this, but implemented it while debugging and I think it's good to leave in.