### PR TITLE
fix: add registry-url and cache config to github actions setup-node

### DIFF
--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -4,15 +4,15 @@ description: 'Setup node & pnpm'
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 18
-        registry-url: 'https://registry.npmjs.org'
-        cache: 'pnpm'
     - uses: pnpm/action-setup@v2
       with:
         version: 7
         run_install: |
           - recursive: true
             args: [--frozen-lockfile, --strict-peer-dependencies]
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+        registry-url: 'https://registry.npmjs.org'
+        cache: 'pnpm'
 

--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -7,6 +7,8 @@ runs:
     - uses: actions/setup-node@v3
       with:
         node-version: 18
+        registry-url: 'https://registry.npmjs.org'
+        cache: 'pnpm'
     - uses: pnpm/action-setup@v2
       with:
         version: 7

--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -8,7 +8,6 @@ runs:
       with:
         node-version: 18
         registry-url: 'https://registry.npmjs.org'
-        cache: 'pnpm'
     - uses: pnpm/action-setup@v2
       with:
         version: 7

--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -8,6 +8,7 @@ runs:
       with:
         node-version: 18
         registry-url: 'https://registry.npmjs.org'
+        cache: 'pnpm'
     - uses: pnpm/action-setup@v2
       with:
         version: 7


### PR DESCRIPTION
Cutting a new release earlier today failed. Fortunately @alanshaw and @olizilla noticed that our working w3protocol builds have two extra lines of relevant config, one of which seems to be the culprit:

> @alanshaw
> Only difference I can see is with w3ui and w3protocol is that setup-node in w3protocol sets cache: pnpm and registry-url: 'https://registry.npmjs.org' https://github.com/web3-storage/w3protocol/blob/4d72ba3a1ce2564cda13c62137967613b18334a7/.github/workflows/release.yml#L47-L48 which is not being set here: https://github.com/web3-storage/w3ui/blob/0c661c6f4d28776b4ac7ad1aea3e0958186f8480/.github/actions/pnpm/action.yml#L7-L9

> olizilla
> it looks like registry-url must be set for setup-node to configure npm with an auth token: https://github.com/actions/setup-node/blob/ae9f0f7448e93b1be0f44663e79763dbdffcc4da/src/main.ts#L56-L60

add these lines and pray to the release gods!