### PR TITLE
chore: document getCurrentSpace and getSpaces

### DIFF
--- a/packages/keyring-core/src/index.ts
+++ b/packages/keyring-core/src/index.ts
@@ -124,7 +124,7 @@ export interface ServiceConfig {
 
 /**
  * Convenience function for returning an agent's current Space.
- * @param agent 
+ * @param agent
  * @returns the currently selected Space for the given agent
  */
 export function getCurrentSpace (agent: Agent): Space | undefined {
@@ -136,7 +136,7 @@ export function getCurrentSpace (agent: Agent): Space | undefined {
 
 /**
  * Convenience function for returning all of an agent's Spaces.
- * @param agent 
+ * @param agent
  * @returns all of the given agent's Spaces
  */
 export function getSpaces (agent: Agent): Space[] {

--- a/packages/keyring-core/src/index.ts
+++ b/packages/keyring-core/src/index.ts
@@ -122,6 +122,11 @@ export interface ServiceConfig {
   connection?: ConnectionView<Service>
 }
 
+/**
+ * Convenience function for returning an agent's current Space.
+ * @param agent 
+ * @returns the currently selected Space for the given agent
+ */
 export function getCurrentSpace (agent: Agent): Space | undefined {
   const did = agent.currentSpace()
   if (did == null) return
@@ -129,6 +134,11 @@ export function getCurrentSpace (agent: Agent): Space | undefined {
   return new Space(did, meta)
 }
 
+/**
+ * Convenience function for returning all of an agent's Spaces.
+ * @param agent 
+ * @returns all of the given agent's Spaces
+ */
 export function getSpaces (agent: Agent): Space[] {
   const spaces: Space[] = []
   for (const [did, meta] of agent.spaces.entries()) {


### PR DESCRIPTION
Mainly doing this to get release-please to queue up a new keyring-core release after the previous one failed in a way that required updates to the build configs.