### PR TITLE
fix: add _headers

### DIFF
--- a/examples/react/w3console/public/_headers
+++ b/examples/react/w3console/public/_headers
@@ -1,0 +1,10 @@
+/*.html
+  Content-Type: text/html
+/*.css
+  Content-Type: text/css
+/*.js
+  Content-Type: text/javascript
+/*.ico
+  Content-Type: image/vnd.microsoft.icon
+/*.svg
+  Content-Type: image/svg+xml


### PR DESCRIPTION
IDK why but cloudflare pages is not setting `Content-Type` header. This PR adds a [`_headers` file](https://developers.cloudflare.com/pages/platform/headers) that sets them for the file types we currently generate.