### PR TITLE
chore: pass VITE_W3UP_PROVIDER along to registerSpace

### DIFF
--- a/examples/react/w3console/src/components/SpaceCreator.tsx
+++ b/examples/react/w3console/src/components/SpaceCreator.tsx
@@ -36,7 +36,7 @@ export function SpaceCreatorForm ({
         await createSpace(name)
         // ignore this because the Space UI should handle helping the user recover
         // from space registration failure
-        await registerSpace(account)
+        void registerSpace(account, {provider: import.meta.env.VITE_W3UP_PROVIDER})
       } catch (error) {
         /* eslint-disable no-console */
         console.error(error)

--- a/packages/keyring-core/src/index.ts
+++ b/packages/keyring-core/src/index.ts
@@ -93,6 +93,10 @@ export interface KeyringContextState {
   account?: string
 }
 
+export interface RegisterSpaceOpts {
+  provider?: DID<'web'>
+}
+
 export interface KeyringContextActions {
   /**
    * Load the user agent and all stored data from secure storage.
@@ -125,7 +129,7 @@ export interface KeyringContextActions {
    * storage. Use cancelRegisterSpace to abort. Automatically sets the
    * newly registered space as the current space.
    */
-  registerSpace: (email: string) => Promise<void>
+  registerSpace: (email: string, opts?: RegisterSpaceOpts) => Promise<void>
   /**
    * Abort an ongoing account registration.
    */

--- a/packages/react-keyring/src/providers/Keyring.tsx
+++ b/packages/react-keyring/src/providers/Keyring.tsx
@@ -10,7 +10,8 @@ import {
 import type {
   KeyringContextState,
   KeyringContextActions,
-  ServiceConfig
+  ServiceConfig,
+  RegisterSpaceOpts
 } from '@w3ui/keyring-core'
 import type { Agent } from '@web3-storage/access'
 import type { Abilities } from '@web3-storage/access/types'
@@ -129,7 +130,7 @@ export function KeyringProvider ({
     return did
   }
 
-  const registerSpace = async (email: string): Promise<void> => {
+  const registerSpace = async (email: string, opts: RegisterSpaceOpts = {}): Promise<void> => {
     const agent = await getAgent()
     const controller = new AbortController()
     setRegisterAbortController(controller)
@@ -137,7 +138,7 @@ export function KeyringProvider ({
     try {
       await agent.registerSpace(email, {
         signal: controller.signal,
-        provider: agent.connection.id.did() as DID<'web'>
+        provider: opts.provider ?? (agent.connection.id.did() as DID<'web'>)
       })
       setSpace(getCurrentSpaceInAgent(agent))
       setSpaces(getSpaces(agent))

--- a/packages/react/src/SpaceCreator.tsx
+++ b/packages/react/src/SpaceCreator.tsx
@@ -38,7 +38,7 @@ export function SpaceCreator ({
       await createSpace(name)
       // ignore this because the Space UI should handle helping the user recover
       // from space registration failure
-      void registerSpace(email)
+      void registerSpace(email, {provider: import.meta.env.VITE_W3UP_PROVIDER})
     } catch (error) {
       /* eslint-disable no-console */
       console.error(error)

--- a/packages/react/src/SpaceCreator.tsx
+++ b/packages/react/src/SpaceCreator.tsx
@@ -38,7 +38,7 @@ export function SpaceCreator ({
       await createSpace(name)
       // ignore this because the Space UI should handle helping the user recover
       // from space registration failure
-      void registerSpace(email, {provider: import.meta.env.VITE_W3UP_PROVIDER})
+      void registerSpace(email)
     } catch (error) {
       /* eslint-disable no-console */
       console.error(error)


### PR DESCRIPTION
Pass the value of the VITE_W3UP_PROVIDER env variable along to registerSpace. This lets us configure the provider used during space registration at the app level.