### PR TITLE
fix: set version numbers for packages release-please fumbled

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,15 +1,15 @@
 {
-  "packages/react-uploader": "4.0.0",
-  "packages/react-uploads-list": "3.0.0",
+  "packages/keyring-core": "3.0.0",
   "packages/uploader-core": "5.0.0",
   "packages/uploads-list-core": "3.0.0",
+  "packages/react-keyring": "4.0.0",
+  "packages/react-uploader": "4.0.0",
+  "packages/react-uploads-list": "3.0.0",
+  "packages/vue-keyring": "3.0.0",
   "packages/vue-uploader": "4.0.0",
+  "packages/vue-uploads-list": "3.0.0",
+  "packages/solid-keyring": "3.0.0",
   "packages/solid-uploader": "4.0.0",
   "packages/solid-uploads-list": "3.0.0",
-  "packages/vue-uploads-list": "3.0.0",
-  "packages/keyring-core": "3.0.0",
-  "packages/solid-keyring": "3.0.0",
-  "packages/react-keyring": "4.0.0",
-  "packages/vue-keyring": "3.0.0",
   "examples/react/w3console": "1.1.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,16 +2,28 @@
   "separate-pull-requests": true,
   "packages": {
     "packages/react-keyring": {},
-    "packages/react-uploader": {},
-    "packages/react-uploads-list": {},
+    "packages/react-uploader": {
+      "release-as": "4.0.0"
+    },
+    "packages/react-uploads-list": {
+      "release-as": "3.0.0"
+    },
 
     "packages/solid-keyring": {},
-    "packages/solid-uploader": {},
-    "packages/solid-uploads-list": {},
+    "packages/solid-uploader": {
+      "release-as": "4.0.0"
+    },
+    "packages/solid-uploads-list": {
+      "release-as": "3.0.0"
+    },
 
     "packages/vue-keyring": {},
-    "packages/vue-uploader": {},
-    "packages/vue-uploads-list": {},
+    "packages/vue-uploader": {
+      "release-as": "4.0.0"
+    },
+    "packages/vue-uploads-list": {
+      "release-as": "3.0.0"
+    },
 
     "packages/keyring-core": {},
     "packages/uploader-core": {},


### PR DESCRIPTION
I tried to merge more than one release-please PR at once and it really hated it, leaving 6 packages in a confusing state. I want to push them again, which afaict means setting version numbers in the config file temporarily.

I will remove these once the release is done.