### PR TITLE
fix: wait for register space before returning from space create onSubmit

### DIFF
--- a/examples/react/w3console/src/components/SpaceCreator.tsx
+++ b/examples/react/w3console/src/components/SpaceCreator.tsx
@@ -34,9 +34,7 @@ export function SpaceCreatorForm ({
       setSubmitted(true)
       try {
         await createSpace(name)
-        // ignore this because the Space UI should handle helping the user recover
-        // from space registration failure
-        void registerSpace(account, {provider: import.meta.env.VITE_W3UP_PROVIDER})
+        await registerSpace(account, {provider: import.meta.env.VITE_W3UP_PROVIDER})
       } catch (error) {
         /* eslint-disable no-console */
         console.error(error)


### PR DESCRIPTION
because we weren't `await`ing here the space creation UI would flash empty again, which was very confusing