### PR TITLE
chore: use workspace version of keyring from playground

### DIFF
--- a/examples/react/playground/package.json
+++ b/examples/react/playground/package.json
@@ -12,7 +12,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@w3ui/keyring-core": "workspace:^2.0.1",
+    "@w3ui/keyring-core": "workspace:^",
     "@w3ui/react": "workspace:^",
     "@w3ui/react-keyring": "workspace:^",
     "@w3ui/react-uploader": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,7 +134,7 @@ importers:
       '@types/react-dom': ^18.0.9
       '@ucanto/interface': ^6.2.0
       '@vitejs/plugin-react': ^3.0.0
-      '@w3ui/keyring-core': workspace:^2.0.1
+      '@w3ui/keyring-core': workspace:^
       '@w3ui/react': workspace:^
       '@w3ui/react-keyring': workspace:^
       '@w3ui/react-uploader': workspace:^


### PR DESCRIPTION
pnpm install fails without this

fixes: https://github.com/web3-storage/w3ui/issues/469

License: MIT