### PR TITLE
fix: w3console email check page improvements

### DIFF
--- a/examples/react/w3console/src/components/Authenticator.tsx
+++ b/examples/react/w3console/src/components/Authenticator.tsx
@@ -41,12 +41,15 @@ export function AuthenticationSubmitted (): JSX.Element {
 
   return (
     <div className='authenticator'>
-      <div className='bg-gray-400 px-24 py-16 rounded-md'>
-        <h1 className='text-xl'>Verify your email address!</h1>
+      <div className='text-white bg-gradient-to-br from-blue-500 to-cyan-500 rounded-xl shadow-md px-10 pt-8 pb-8'>
+        <div className='flex flex-row gap-4 mb-8 flex justify-center gap-4'>
+          <Logo className='w-36'/>
+        </div>
+        <h1 className='text-xl font-semibold'>Verify your email address!</h1>
         <p className='pt-2 pb-4'>
-          Click the link in the email we sent to {email} to authorize this agent.
+          Click the link in the email we sent to <span className='font-semibold tracking-wide'>{email}</span> to authorize this agent.
         </p>
-        <AuthCore.CancelButton className='w3ui-button w-full'>
+        <AuthCore.CancelButton className='w3ui-button hidden' >
           Cancel
         </AuthCore.CancelButton>
       </div>


### PR DESCRIPTION
the colors match the login box, so are less jarring, and the cancel button is hidden! it doesn't work yet! See next PR.

**after**
<img width="1582" alt="Screenshot 2023-03-24 at 14 41 25" src="https://user-images.githubusercontent.com/58871/227556717-046a554e-72ff-47ce-a506-85cca7e40dd4.png">

**before**
<img width="1582" alt="Screenshot 2023-03-24 at 14 41 50" src="https://user-images.githubusercontent.com/58871/227556789-970db3b7-7965-4164-941e-ef781b139d83.png">


License: MIT