### PR TITLE
feat: add docs page

### DIFF
--- a/examples/react/w3console/src/components/Layout.tsx
+++ b/examples/react/w3console/src/components/Layout.tsx
@@ -18,7 +18,6 @@ export const DefaultLayout: LayoutComponent = ({ sidebar = <div></div>, children
               <a className='text-xs block text-center mt-2' href='/terms'>Terms</a>
               <a className='text-xs block text-center mt-2' href='/docs'>Docs</a>
               <a className='text-xs block text-center mt-2' href='https://github.com/web3-storage/w3ui/issues'>Support</a>
-
             </div>
           </div>
         </div>

--- a/examples/react/w3console/src/components/Layout.tsx
+++ b/examples/react/w3console/src/components/Layout.tsx
@@ -1,0 +1,31 @@
+import { tosUrl, Logo } from '../brand'
+
+interface LayoutComponentProps {
+  sidebar?: JSX.Element | JSX.Element[]
+  children: JSX.Element | JSX.Element[]
+}
+type LayoutComponent = (props: LayoutComponentProps) => JSX.Element
+
+export const DefaultLayout: LayoutComponent = ({ sidebar = <div></div>, children }) => {
+  return (
+    <div className='flex min-h-full w-full'>
+      <nav className='flex-none w-64 bg-gray-900 text-white px-4 pb-4 border-r border-gray-800 h-screen'>
+        <div className='flex flex-col justify-between h-full'>
+          {sidebar}
+          <div className='flex flex-col items-center'>
+            <a href='/'><Logo className='w-36 mb-2' /></a>
+            <div className='flex flex-row space-x-2'>
+              <a className='text-xs block text-center mt-2' href='/terms'>Terms</a>
+              <a className='text-xs block text-center mt-2' href='/docs'>Docs</a>
+              <a className='text-xs block text-center mt-2' href='https://github.com/web3-storage/w3ui/issues'>Support</a>
+
+            </div>
+          </div>
+        </div>
+      </nav>
+      <main className='grow bg-gray-dark text-white p-4 h-screen overflow-scroll'>
+        {children}
+      </main>
+    </div>
+  )
+}

--- a/examples/react/w3console/src/components/elements.tsx
+++ b/examples/react/w3console/src/components/elements.tsx
@@ -1,0 +1,8 @@
+interface LinkProps {
+  className?: string
+  href: string
+  children: string | JSX.Element | JSX.Element[]
+}
+export const Link = ({ className = '', ...props }: LinkProps) => (
+  <a className={`underline ${className}`} {...props} />
+)

--- a/examples/react/w3console/src/pages/docs.tsx
+++ b/examples/react/w3console/src/pages/docs.tsx
@@ -5,7 +5,7 @@ export default function Docs () {
   return (
     <DefaultLayout>
       <div className='flex flex-col justify-start items-center min-h-full w-full text-left text-white p-8'>
-        <h1 className='text-3xl mb-8'>Welcome to the w3console beta!</h1>
+        <h1 className='text-3xl mb-8 font-bold'>Welcome to the w3console beta!</h1>
         <p className='mb-4 w-4/5'>
           We're excited that you're using the w3up web console. This is a web-based interface
           to <Link href='https://github.com/web3-storage/w3up'>w3up</Link>, designed to make it easy

--- a/examples/react/w3console/src/pages/docs.tsx
+++ b/examples/react/w3console/src/pages/docs.tsx
@@ -1,0 +1,38 @@
+import { DefaultLayout } from '../components/Layout'
+import { Link } from '../components/elements'
+
+export default function Docs () {
+  return (
+    <DefaultLayout>
+      <div className='flex flex-col justify-start items-center min-h-full w-full text-left text-white p-8'>
+        <h1 className='text-3xl mb-8'>Welcome to the w3console beta!</h1>
+        <p className='mb-4 w-4/5'>
+          We're excited that you're using the w3up web console. This is a web-based interface
+          to <Link href='https://github.com/web3-storage/w3up'>w3up</Link>, designed to make it easy
+          for you to upload data to the Filecoin network.
+        </p>
+        <p className='mb-4 min-w-fit w-4/5'>
+          If you are a developer interested in integrating with w3up, please check out:
+        </p>
+        <ul className='mb-4 w-4/5 list-disc pl-8'>
+          <li>
+            Our command line tool <Link href='https://github.com/web3-storage/w3cli#getting-started'>w3</Link>
+          </li>
+          <li>
+            Our JavaScript library <Link href='https://github.com/web3-storage/w3up/tree/main/packages/w3up-client#about'>w3up-client</Link>
+          </li>
+          <li>
+            Our library of headless React, Vue and SolidJS widgets <Link href='https://beta.ui.web3.storage/'>w3ui</Link>
+          </li>
+        </ul>
+        <p className='mb-4 w-4/5'>
+          Otherwise, visit the <Link href='https://github.com/web3-storage/w3up'>w3up</Link> repository
+          where you'll find documentation and source code for the w3up protocol. You may
+          also be interested in reading the <Link href='https://github.com/web3-storage/specs'>w3up specifications</Link> and
+          learning more about <Link href='https://github.com/web3-storage/w3infra'>the operational infrastructure code</Link> that
+          powers our implementation of w3up.
+        </p>
+      </div>
+    </DefaultLayout>
+  )
+}

--- a/examples/react/w3console/src/pages/index.tsx
+++ b/examples/react/w3console/src/pages/index.tsx
@@ -14,8 +14,8 @@ import { UploadsList } from '../components/UploadsList'
 import { SpaceFinder } from '../components/SpaceFinder'
 import { SpaceCreatorForm, SpaceCreator } from '../components/SpaceCreator'
 import { AuthenticationEnsurer } from '../components/Authenticator'
+import { DefaultLayout } from '../components/Layout'
 import Loader from '../components/Loader'
-import { tosUrl, Logo } from '../brand'
 
 function SpaceRegistrar (): JSX.Element {
   const [{ account }, { registerSpace }] = useKeyring()
@@ -185,27 +185,18 @@ export default function Home (): JSX.Element {
   return (
     <AuthenticationEnsurer>
       <SpaceEnsurer>
-        <div className='flex min-h-full w-full'>
-          <nav className='flex-none w-64 bg-gray-900 text-white px-4 pb-4 border-r border-gray-800'>
-            <div className='flex flex-col justify-between min-h-full'>
-              <div class='flex-none'>
-                <SpaceSelector
-                  selected={space}
-                  setSelected={viewSpace}
-                  spaces={spaces}
-                />
-              </div>
-              <div className='flex flex-col items-center'>
-                <SpaceCreator className='mb-8' />
-                <Logo className='w-36 mb-2'/>
-                <a className='text-xs block text-center mt-2' href={tosUrl}>Terms</a>
-              </div>
-            </div>
-          </nav>
-          <main className='grow bg-gray-dark text-white p-4'>
-            <SpaceSection viewSpace={viewSpace} share={share} setShare={setShare} />
-          </main>
-        </div>
+        <DefaultLayout sidebar={
+          <div class='flex-grow flex flex-col justify-between'>
+            <SpaceSelector
+              selected={space}
+              setSelected={viewSpace}
+              spaces={spaces}
+            />
+            <SpaceCreator className='mb-8 self-center' />
+          </div>
+        }>
+          <SpaceSection viewSpace={viewSpace} share={share} setShare={setShare} />
+        </DefaultLayout>
       </SpaceEnsurer>
     </AuthenticationEnsurer>
   )

--- a/examples/react/w3console/src/pages/terms.tsx
+++ b/examples/react/w3console/src/pages/terms.tsx
@@ -1,78 +1,81 @@
-import { Logo, tosUrl } from '../brand'
+import { tosUrl } from '../brand'
+import { DefaultLayout } from '../components/Layout'
+import { Link } from '../components/elements'
 
 export default function Terms () {
   const serviceName = import.meta.env.VITE_W3UP_SERVICE_BRAND_NAME || 'dev.web3.storage'
   return (
-    <div className='flex flex-col justify-start items-center min-h-full w-full bg-gray-900 text-white p-8'>
-      <div className='flex flex-row gap-4'>
-        <Logo className='h-12'/>
-        <h1 className='text-2xl my-4 font-bold'>
-          {serviceName} w3up beta Terms of Service
-        </h1>
-      </div>
-      <p className='my-2 max-w-xl leading-relaxed'>
-        {serviceName} w3up is currently a beta preview feature for {serviceName},
-        and will eventually be used as the primary upload API for {serviceName}.{' '}
-        {serviceName} includes <a className='underline' href="https://github.com/web3-storage/w3up-client">w3up-client</a>,{' '}
-        <a className='underline' href="https://github.com/web3-storage/w3ui">w3ui</a>,{' '}
-        <a className='underline' href="https://github.com/web3-storage/w3cli">w3cli</a>, and the{' '}
-        <a className='underline' href="https://github.com/web3-storage/w3protocol">underlying APIs and services</a>{' '}
-        for uploading data (collectively, the “w3up beta”). By using the {serviceName}{' '}
-        w3up beta, you consent to the general {serviceName} <a className='underline' href={tosUrl}>Terms of Service</a>
-        {import.meta.env.VITE_W3UP_PROVIDER == 'did:web:nft.storage' &&
-          ', meaning you will only upload NFT data (i.e., off-chain NFT metadata and assets) via your account'
-        }
-        .
-      </p>
-      <p className='my-2 max-w-xl leading-relaxed '>
-        {import.meta.env.VITE_W3UP_PROVIDER == 'did:web:web3.storage' &&
-          'Registering for and uploading data to the web3.storage w3up beta is currently free. '
-        }
-        At the end of the preview period, accounts registered through the {serviceName} w3up beta
-        (“w3up account(s)”) will ultimately be integrated with the broader account system of {serviceName}.
-      </p>
-      <h2 className='text-lg my-4 font-bold'>
-        Accounts Linked to Email Addresses
-      </h2>
-      <p className='my-2 max-w-xl leading-relaxed'>
-        In order to register for the {serviceName} w3up beta, you will be required to provide and verify an
-        email address, which will be permanently associated with your {serviceName} w3up account and cannot be changed.
-      </p>
-      <p className='my-2 max-w-xl leading-relaxed'>
-        If you sign up for the {serviceName} w3up beta with the same email address used for a {serviceName} account,
-        at the end of the preview period we will merge your data uploaded through the w3up beta with the {serviceName}{' '}
-        account linked to the same email.
-      </p>
-      <p className='my-2 max-w-xl leading-relaxed'>
-        If you intend to separate uploaded data between web3.storage and NFT.Storage using w3up during the w3up beta period (e.g.,
-        you want your NFT data to be stored for free on NFT.Storage and non-NFT data to be stored for payment on web3.storage),
-        please register for the {import.meta.env.VITE_W3UP_PROVIDER == 'did:web:nft.storage' ? 'web3.storage' : 'NFT.Storage'} w3up beta separately.
-      </p>
-      <h2 className='text-lg my-4 font-bold'>
-        w3up Accounts Moving to {serviceName}
-      </h2>
-
-      {import.meta.env.VITE_W3UP_PROVIDER == 'did:web:web3.storage' &&
-        <div>
-          <p className='my-2 max-w-xl leading-relaxed'>
-            At the end of the preview period, your web3.storage w3up beta account will be integrated with the broader web3.storage
-            account system. You acknowledge that once the preview period ends, all data uploaded through the w3up beta will be combined
-            with existing uploads to your web3.storage account, and any aggregate data volume exceeding the Free Tier data limits of
-            web3.storage during this preview window will eventually require payment for us to continue storing it and making it available.
-          </p>
-          <p className='my-2 max-w-xl leading-relaxed'>
-            Please refer to the web3.storage website for <a className='underline' href="https://web3.storage/pricing/">information on pricing</a>. If you exceed
-            the Free Tier data limits of web3.storage and do not intend to pay, please do not use the w3up beta for long-term storage.
-          </p>
+    <DefaultLayout>
+      <div className='flex flex-col justify-start items-center min-h-full w-full text-white p-8'>
+        <div className='flex flex-row gap-4'>
+          <h1 className='text-2xl my-4 font-bold'>
+            {serviceName} w3up beta Terms of Service
+          </h1>
         </div>
-      }
-      {import.meta.env.VITE_W3UP_PROVIDER == 'did:web:nft.storage' &&
         <p className='my-2 max-w-xl leading-relaxed'>
-          At the end of the preview period, your NFT.Storage w3up beta account will be integrated with the broader NFT.Storage account system.
-          You acknowledge that once the preview period ends, all data uploaded through the w3up beta will be combined with existing uploads to
-          your NFT.Storage account.
+          {serviceName} w3up is currently a beta preview feature for {serviceName},
+          and will eventually be used as the primary upload API for {serviceName}.{' '}
+          {serviceName} includes <Link href="https://github.com/web3-storage/w3up-client">w3up-client</Link>,{' '}
+          <Link href="https://github.com/web3-storage/w3ui">w3ui</Link>,{' '}
+          <Link href="https://github.com/web3-storage/w3cli">w3cli</Link>, and the{' '}
+          <Link href="https://github.com/web3-storage/w3protocol">underlying APIs and services</Link>{' '}
+          for uploading data (collectively, the “w3up beta”). By using the {serviceName}{' '}
+          w3up beta, you consent to the general {serviceName} <Link href={tosUrl}>Terms of Service</Link>
+          {import.meta.env.VITE_W3UP_PROVIDER == 'did:web:nft.storage' &&
+            ', meaning you will only upload NFT data (i.e., off-chain NFT metadata and assets) via your account'
+          }
+          .
         </p>
-      }
-    </div>
+        <p className='my-2 max-w-xl leading-relaxed '>
+          {import.meta.env.VITE_W3UP_PROVIDER == 'did:web:web3.storage' &&
+            'Registering for and uploading data to the web3.storage w3up beta is currently free. '
+          }
+          At the end of the preview period, accounts registered through the {serviceName} w3up beta
+          (“w3up account(s)”) will ultimately be integrated with the broader account system of {serviceName}.
+        </p>
+        <h2 className='text-lg my-4 font-bold'>
+          Accounts Linked to Email Addresses
+        </h2>
+        <p className='my-2 max-w-xl leading-relaxed'>
+          In order to register for the {serviceName} w3up beta, you will be required to provide and verify an
+          email address, which will be permanently associated with your {serviceName} w3up account and cannot be changed.
+        </p>
+        <p className='my-2 max-w-xl leading-relaxed'>
+          If you sign up for the {serviceName} w3up beta with the same email address used for a {serviceName} account,
+          at the end of the preview period we will merge your data uploaded through the w3up beta with the {serviceName}{' '}
+          account linked to the same email.
+        </p>
+        <p className='my-2 max-w-xl leading-relaxed'>
+          If you intend to separate uploaded data between web3.storage and NFT.Storage using w3up during the w3up beta period (e.g.,
+          you want your NFT data to be stored for free on NFT.Storage and non-NFT data to be stored for payment on web3.storage),
+          please register for the {import.meta.env.VITE_W3UP_PROVIDER == 'did:web:nft.storage' ? 'web3.storage' : 'NFT.Storage'} w3up beta separately.
+        </p>
+        <h2 className='text-lg my-4 font-bold'>
+          w3up Accounts Moving to {serviceName}
+        </h2>
+
+        {import.meta.env.VITE_W3UP_PROVIDER == 'did:web:web3.storage' &&
+          <div>
+            <p className='my-2 max-w-xl leading-relaxed'>
+              At the end of the preview period, your web3.storage w3up beta account will be integrated with the broader web3.storage
+              account system. You acknowledge that once the preview period ends, all data uploaded through the w3up beta will be combined
+              with existing uploads to your web3.storage account, and any aggregate data volume exceeding the Free Tier data limits of
+              web3.storage during this preview window will eventually require payment for us to continue storing it and making it available.
+            </p>
+            <p className='my-2 max-w-xl leading-relaxed'>
+              Please refer to the web3.storage website for <Link href="https://web3.storage/pricing/">information on pricing</Link>. If you exceed
+              the Free Tier data limits of web3.storage and do not intend to pay, please do not use the w3up beta for long-term storage.
+            </p>
+          </div>
+        }
+        {import.meta.env.VITE_W3UP_PROVIDER == 'did:web:nft.storage' &&
+          <p className='my-2 max-w-xl leading-relaxed'>
+            At the end of the preview period, your NFT.Storage w3up beta account will be integrated with the broader NFT.Storage account system.
+            You acknowledge that once the preview period ends, all data uploaded through the w3up beta will be combined with existing uploads to
+            your NFT.Storage account.
+          </p>
+        }
+      </div>
+    </DefaultLayout>
   )
 }

--- a/examples/react/w3console/src/pages/terms.tsx
+++ b/examples/react/w3console/src/pages/terms.tsx
@@ -12,7 +12,7 @@ export default function Terms () {
             {serviceName} w3up beta Terms of Service
           </h1>
         </div>
-        <p className='my-2 max-w-xl leading-relaxed'>
+        <p className='my-2 w-4/5 leading-relaxed'>
           {serviceName} w3up is currently a beta preview feature for {serviceName},
           and will eventually be used as the primary upload API for {serviceName}.{' '}
           {serviceName} includes <Link href="https://github.com/web3-storage/w3up-client">w3up-client</Link>,{' '}
@@ -26,7 +26,7 @@ export default function Terms () {
           }
           .
         </p>
-        <p className='my-2 max-w-xl leading-relaxed '>
+        <p className='my-2 w-4/5 leading-relaxed '>
           {import.meta.env.VITE_W3UP_PROVIDER == 'did:web:web3.storage' &&
             'Registering for and uploading data to the web3.storage w3up beta is currently free. '
           }
@@ -36,16 +36,16 @@ export default function Terms () {
         <h2 className='text-lg my-4 font-bold'>
           Accounts Linked to Email Addresses
         </h2>
-        <p className='my-2 max-w-xl leading-relaxed'>
+        <p className='my-2 w-4/5 leading-relaxed'>
           In order to register for the {serviceName} w3up beta, you will be required to provide and verify an
           email address, which will be permanently associated with your {serviceName} w3up account and cannot be changed.
         </p>
-        <p className='my-2 max-w-xl leading-relaxed'>
+        <p className='my-2 w-4/5 leading-relaxed'>
           If you sign up for the {serviceName} w3up beta with the same email address used for a {serviceName} account,
           at the end of the preview period we will merge your data uploaded through the w3up beta with the {serviceName}{' '}
           account linked to the same email.
         </p>
-        <p className='my-2 max-w-xl leading-relaxed'>
+        <p className='my-2 w-4/5 leading-relaxed'>
           If you intend to separate uploaded data between web3.storage and NFT.Storage using w3up during the w3up beta period (e.g.,
           you want your NFT data to be stored for free on NFT.Storage and non-NFT data to be stored for payment on web3.storage),
           please register for the {import.meta.env.VITE_W3UP_PROVIDER == 'did:web:nft.storage' ? 'web3.storage' : 'NFT.Storage'} w3up beta separately.
@@ -56,20 +56,20 @@ export default function Terms () {
 
         {import.meta.env.VITE_W3UP_PROVIDER == 'did:web:web3.storage' &&
           <div>
-            <p className='my-2 max-w-xl leading-relaxed'>
+            <p className='my-2 w-4/5 leading-relaxed'>
               At the end of the preview period, your web3.storage w3up beta account will be integrated with the broader web3.storage
               account system. You acknowledge that once the preview period ends, all data uploaded through the w3up beta will be combined
               with existing uploads to your web3.storage account, and any aggregate data volume exceeding the Free Tier data limits of
               web3.storage during this preview window will eventually require payment for us to continue storing it and making it available.
             </p>
-            <p className='my-2 max-w-xl leading-relaxed'>
+            <p className='my-2 w-4/5 leading-relaxed'>
               Please refer to the web3.storage website for <Link href="https://web3.storage/pricing/">information on pricing</Link>. If you exceed
               the Free Tier data limits of web3.storage and do not intend to pay, please do not use the w3up beta for long-term storage.
             </p>
           </div>
         }
         {import.meta.env.VITE_W3UP_PROVIDER == 'did:web:nft.storage' &&
-          <p className='my-2 max-w-xl leading-relaxed'>
+          <p className='my-2 w-4/5 leading-relaxed'>
             At the end of the preview period, your NFT.Storage w3up beta account will be integrated with the broader NFT.Storage account system.
             You acknowledge that once the preview period ends, all data uploaded through the w3up beta will be combined with existing uploads to
             your NFT.Storage account.

--- a/examples/react/w3console/src/pages/terms.tsx
+++ b/examples/react/w3console/src/pages/terms.tsx
@@ -55,7 +55,7 @@ export default function Terms () {
         </h2>
 
         {import.meta.env.VITE_W3UP_PROVIDER == 'did:web:web3.storage' &&
-          <div>
+          <>
             <p className='my-2 w-4/5 leading-relaxed'>
               At the end of the preview period, your web3.storage w3up beta account will be integrated with the broader web3.storage
               account system. You acknowledge that once the preview period ends, all data uploaded through the w3up beta will be combined
@@ -66,7 +66,7 @@ export default function Terms () {
               Please refer to the web3.storage website for <Link href="https://web3.storage/pricing/">information on pricing</Link>. If you exceed
               the Free Tier data limits of web3.storage and do not intend to pay, please do not use the w3up beta for long-term storage.
             </p>
-          </div>
+          </>
         }
         {import.meta.env.VITE_W3UP_PROVIDER == 'did:web:nft.storage' &&
           <p className='my-2 w-4/5 leading-relaxed'>


### PR DESCRIPTION
Refactor a bit to make it easier to wrap terms and docs in the same layout. Previously there was no link to get back to the main page from terms, which was not great.

resolves #398 

<img width="1223" alt="Screenshot 2023-03-29 at 6 20 18 PM" src="https://user-images.githubusercontent.com/1113/228703406-ba85501f-e841-47fe-a394-d5200b7f7eaf.png">


<img width="1226" alt="Screenshot 2023-03-29 at 6 16 11 PM" src="https://user-images.githubusercontent.com/1113/228702897-10c48408-c112-4ca8-a488-da3ac6e981df.png">

