### PR TITLE
fix: types location

### DIFF
--- a/examples/react/playground/package.json
+++ b/examples/react/playground/package.json
@@ -12,7 +12,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@w3ui/keyring-core": "workspace:^2.0.1",
+    "@w3ui/keyring-core": "workspace:^",
     "@w3ui/react": "workspace:^",
     "@w3ui/react-keyring": "workspace:^",
     "@w3ui/react-uploader": "workspace:^",

--- a/packages/keyring-core/package.json
+++ b/packages/keyring-core/package.json
@@ -8,7 +8,7 @@
     "module": "build/esm/index.js",
     "main": "build/cjs/index.js",
     "browser": "build/umd/index.production.js",
-    "types": "build/types/index.d.ts"
+    "types": "build/types/src/index.d.ts"
   },
   "scripts": {
     "compile": "../../node_modules/.bin/tsc -p tsconfig.json --noEmit --emitDeclarationOnly false",


### PR DESCRIPTION
`test` was added to the `tsconfig.json` at some point and the types output started to include the `test` directory instead of just the contents of `src`.