### PR TITLE
feat: get w3console looking acceptable on mobile

### DIFF
--- a/examples/react/w3console/package.json
+++ b/examples/react/w3console/package.json
@@ -10,8 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@headlessui/react": "^1.7.7",
-    "@heroicons/react": "^2.0.13",
+    "@headlessui/react": "^1.7.13",
+    "@heroicons/react": "^2.0.17",
     "@ipld/car": "^5.1.0",
     "@ipld/dag-ucan": "^3.2.0",
     "@w3ui/keyring-core": "workspace:^",

--- a/examples/react/w3console/src/components/Layout.tsx
+++ b/examples/react/w3console/src/components/Layout.tsx
@@ -3,115 +3,88 @@ import { Fragment, useState } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline'
 
-interface LayoutComponentProps {
-  sidebar?: JSX.Element | JSX.Element[]
-  children: JSX.Element | JSX.Element[]
-}
-type LayoutComponent = (props: LayoutComponentProps) => JSX.Element
-
 const navLinks = [
   { name: 'Terms', href: '/terms' },
   { name: 'Docs', href: '/docs' },
   { name: 'Support', href: 'https://github.com/web3-storage/w3ui/issues' },
 ]
 
-export const DefaultLayout: LayoutComponent = ({ sidebar = <div></div>, children }) => {
+interface SidebarComponentProps {
+  sidebar?: JSX.Element | JSX.Element[]
+}
+
+function Sidebar ({ sidebar = <div></div> }: SidebarComponentProps): JSX.Element {
+  return (
+    <nav className='flex-none w-64 bg-gray-900 text-white px-4 pb-4 border-r border-gray-800 h-screen'>
+      <div className='flex flex-col justify-between h-full'>
+        {sidebar}
+        <div className='flex flex-col items-center'>
+          <a href='/'><Logo className='w-36 mb-2' /></a>
+          <div className='flex flex-row space-x-2'>
+            {navLinks.map(link => (
+              <a className='text-xs block text-center mt-2' href={link.href}>{link.name}</a>
+            ))}
+          </div>
+        </div>
+      </div>
+    </nav>
+  )
+}
+
+interface LayoutComponentProps extends SidebarComponentProps {
+  children: JSX.Element | JSX.Element[]
+}
+
+export function DefaultLayout ({ sidebar = <div></div>, children }: LayoutComponentProps): JSX.Element {
   const [sidebarOpen, setSidebarOpen] = useState(false)
 
   return (
-    <>
-      <div>
-        {/* Hamburger menu sidebar for smol screens */}
-        <Transition.Root show={sidebarOpen} as={Fragment}>
-          <Dialog as="div" className="relative z-50 lg:hidden" onClose={setSidebarOpen}>
+    <div className='flex min-h-full w-full text-white'>
+      {/* dialog sidebar for narrow browsers */}
+      <Transition.Root show={sidebarOpen} >
+        <Dialog onClose={() => setSidebarOpen(false)} as='div' className='relative z-50'>
+          <Transition.Child
+            as={Fragment}
+            enter="transition-opacity duration-200"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="transition-opacity duration-400"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0">
+            <div className="fixed inset-0 bg-black/70" aria-hidden="true" />
+          </Transition.Child>
+          <div className="fixed inset-0 flex justify-left">
             <Transition.Child
               as={Fragment}
-              enter="transition-opacity ease-linear duration-300"
-              enterFrom="opacity-0"
-              enterTo="opacity-100"
-              leave="transition-opacity ease-linear duration-300"
-              leaveFrom="opacity-100"
-              leaveTo="opacity-0"
-            >
-              <div className="fixed inset-0 bg-gray-900/80" />
+              enter="transition duration-200"
+              enterFrom="-translate-x-full"
+              enterTo="translate-x-0"
+              leave="transition duration-400"
+              leaveFrom="translate-x-0"
+              leaveTo="-translate-x-full">
+              <Dialog.Panel>
+                <XMarkIcon className='text-white w-6 h-6 fixed top-2 -right-8' onClick={() => setSidebarOpen(false)} />
+                <Sidebar sidebar={sidebar} />
+              </Dialog.Panel>
             </Transition.Child>
-
-            <div className="fixed inset-0 flex">
-              <Transition.Child
-                as={Fragment}
-                enter="transition ease-in-out duration-300 transform"
-                enterFrom="-translate-x-full"
-                enterTo="translate-x-0"
-                leave="transition ease-in-out duration-300 transform"
-                leaveFrom="translate-x-0"
-                leaveTo="-translate-x-full"
-              >
-                <Dialog.Panel className="relative flex w-full max-w-xs flex-1">
-                  <Transition.Child
-                    as={Fragment}
-                    enter="ease-in-out duration-300"
-                    enterFrom="opacity-0"
-                    enterTo="opacity-100"
-                    leave="ease-in-out duration-300"
-                    leaveFrom="opacity-100"
-                    leaveTo="opacity-0"
-                  >
-                    <div className="absolute right-0 top-0 flex w-16 justify-center pt-5">
-                      <button type="button" className="-m-2.5 p-2.5" onClick={() => setSidebarOpen(false)}>
-                        <span className="sr-only">Close sidebar</span>
-                        <XMarkIcon className="h-6 w-6 text-white" aria-hidden="true" />
-                      </button>
-                    </div>
-                  </Transition.Child>
-                  <nav className='flex-none w-64 bg-gray-900 text-white px-4 pb-4 border-r border-gray-800 h-screen'>
-                    <div className='flex flex-col justify-between h-full'>
-                      {sidebar}
-                      <div className='flex flex-col items-center'>
-                        <a href='/'><Logo className='w-36 mb-2' /></a>
-                        <div className='flex flex-row space-x-2'>
-                          {navLinks.map(link => (
-                            <a className='text-xs block text-center mt-2' href={link.href}>{link.name}</a>
-                          ))}
-                        </div>
-                      </div>
-                    </div>
-                  </nav>
-                </Dialog.Panel>
-              </Transition.Child>
-            </div>
-          </Dialog>
-        </Transition.Root>
-
-        {/* Static sidebar for desktop */}
-        <div className="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
-          <nav className='flex-none w-64 bg-gray-900 text-white px-4 pb-4 border-r border-gray-800 h-screen'>
-            <div className='flex flex-col justify-between h-full'>
-              {sidebar}
-              <div className='flex flex-col items-center'>
-                <a href='/'><Logo className='w-36 mb-2' /></a>
-                <div className='flex flex-row space-x-2'>
-                  {navLinks.map(link => (
-                    <a className='text-xs block text-center mt-2' href={link.href}>{link.name}</a>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </nav>
-        </div>
-
-        <div className="lg:pl-72 text-white">
-          <div className="sticky top-0 z-40 flex justify-between h-16 shrink-0 items-center gap-x-4 px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:hidden">
-            <button type="button" className="-m-2.5 p-2.5 text-gray-700 lg:hidden" onClick={() => setSidebarOpen(true)}>
-              <span className="sr-only">Open sidebar</span>
-              <Bars3Icon className="text-white h-6 w-6" aria-hidden="true" />
-            </button>
-            <a href='/'><Logo className='w-36 mb-2' /></a>
           </div>
-          <main className="grow bg-gray-dark p-4 h-screen overflow-scroll">
-            {children}
-          </main>
-        </div>
+        </Dialog>
+      </Transition.Root>
+
+      {/* static sidebar for wide browsers */}
+      <div className='hidden lg:block'>
+        <Sidebar sidebar={sidebar} />
       </div>
-    </>
+      <div className='w-full h-screen overflow-scroll'>
+        {/* top nav bar for narrow browsers, mainly to have a place to put the hamburger */}
+        <div className='lg:hidden flex justify-between pt-4 px-4'>
+          <Bars3Icon className='w-6 h-6' onClick={() => setSidebarOpen(true)} />
+          <a href='/'><Logo className='w-36 mb-2' /></a>
+        </div>
+        <main className='grow bg-gray-dark text-white p-4'>
+          {children}
+        </main>
+      </div>
+    </div>
   )
 }

--- a/examples/react/w3console/src/components/Layout.tsx
+++ b/examples/react/w3console/src/components/Layout.tsx
@@ -1,4 +1,7 @@
-import { tosUrl, Logo } from '../brand'
+import { Logo } from '../brand'
+import { Fragment, useState } from 'react'
+import { Dialog, Transition } from '@headlessui/react'
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline'
 
 interface LayoutComponentProps {
   sidebar?: JSX.Element | JSX.Element[]
@@ -6,25 +9,109 @@ interface LayoutComponentProps {
 }
 type LayoutComponent = (props: LayoutComponentProps) => JSX.Element
 
+const navLinks = [
+  { name: 'Terms', href: '/terms' },
+  { name: 'Docs', href: '/docs' },
+  { name: 'Support', href: 'https://github.com/web3-storage/w3ui/issues' },
+]
+
 export const DefaultLayout: LayoutComponent = ({ sidebar = <div></div>, children }) => {
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+
   return (
-    <div className='flex min-h-full w-full'>
-      <nav className='flex-none w-64 bg-gray-900 text-white px-4 pb-4 border-r border-gray-800 h-screen'>
-        <div className='flex flex-col justify-between h-full'>
-          {sidebar}
-          <div className='flex flex-col items-center'>
-            <a href='/'><Logo className='w-36 mb-2' /></a>
-            <div className='flex flex-row space-x-2'>
-              <a className='text-xs block text-center mt-2' href='/terms'>Terms</a>
-              <a className='text-xs block text-center mt-2' href='/docs'>Docs</a>
-              <a className='text-xs block text-center mt-2' href='https://github.com/web3-storage/w3ui/issues'>Support</a>
+    <>
+      <div>
+        {/* Hamburger menu sidebar for smol screens */}
+        <Transition.Root show={sidebarOpen} as={Fragment}>
+          <Dialog as="div" className="relative z-50 lg:hidden" onClose={setSidebarOpen}>
+            <Transition.Child
+              as={Fragment}
+              enter="transition-opacity ease-linear duration-300"
+              enterFrom="opacity-0"
+              enterTo="opacity-100"
+              leave="transition-opacity ease-linear duration-300"
+              leaveFrom="opacity-100"
+              leaveTo="opacity-0"
+            >
+              <div className="fixed inset-0 bg-gray-900/80" />
+            </Transition.Child>
+
+            <div className="fixed inset-0 flex">
+              <Transition.Child
+                as={Fragment}
+                enter="transition ease-in-out duration-300 transform"
+                enterFrom="-translate-x-full"
+                enterTo="translate-x-0"
+                leave="transition ease-in-out duration-300 transform"
+                leaveFrom="translate-x-0"
+                leaveTo="-translate-x-full"
+              >
+                <Dialog.Panel className="relative flex w-full max-w-xs flex-1">
+                  <Transition.Child
+                    as={Fragment}
+                    enter="ease-in-out duration-300"
+                    enterFrom="opacity-0"
+                    enterTo="opacity-100"
+                    leave="ease-in-out duration-300"
+                    leaveFrom="opacity-100"
+                    leaveTo="opacity-0"
+                  >
+                    <div className="absolute right-0 top-0 flex w-16 justify-center pt-5">
+                      <button type="button" className="-m-2.5 p-2.5" onClick={() => setSidebarOpen(false)}>
+                        <span className="sr-only">Close sidebar</span>
+                        <XMarkIcon className="h-6 w-6 text-white" aria-hidden="true" />
+                      </button>
+                    </div>
+                  </Transition.Child>
+                  <nav className='flex-none w-64 bg-gray-900 text-white px-4 pb-4 border-r border-gray-800 h-screen'>
+                    <div className='flex flex-col justify-between h-full'>
+                      {sidebar}
+                      <div className='flex flex-col items-center'>
+                        <a href='/'><Logo className='w-36 mb-2' /></a>
+                        <div className='flex flex-row space-x-2'>
+                          {navLinks.map(link => (
+                            <a className='text-xs block text-center mt-2' href={link.href}>{link.name}</a>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  </nav>
+                </Dialog.Panel>
+              </Transition.Child>
             </div>
-          </div>
+          </Dialog>
+        </Transition.Root>
+
+        {/* Static sidebar for desktop */}
+        <div className="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
+          <nav className='flex-none w-64 bg-gray-900 text-white px-4 pb-4 border-r border-gray-800 h-screen'>
+            <div className='flex flex-col justify-between h-full'>
+              {sidebar}
+              <div className='flex flex-col items-center'>
+                <a href='/'><Logo className='w-36 mb-2' /></a>
+                <div className='flex flex-row space-x-2'>
+                  {navLinks.map(link => (
+                    <a className='text-xs block text-center mt-2' href={link.href}>{link.name}</a>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </nav>
         </div>
-      </nav>
-      <main className='grow bg-gray-dark text-white p-4 h-screen overflow-scroll'>
-        {children}
-      </main>
-    </div>
+
+        <div className="lg:pl-72 text-white">
+          <div className="sticky top-0 z-40 flex justify-between h-16 shrink-0 items-center gap-x-4 px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:hidden">
+            <button type="button" className="-m-2.5 p-2.5 text-gray-700 lg:hidden" onClick={() => setSidebarOpen(true)}>
+              <span className="sr-only">Open sidebar</span>
+              <Bars3Icon className="text-white h-6 w-6" aria-hidden="true" />
+            </button>
+            <a href='/'><Logo className='w-36 mb-2' /></a>
+          </div>
+          <main className="grow bg-gray-dark p-4 h-screen overflow-scroll">
+            {children}
+          </main>
+        </div>
+      </div>
+    </>
   )
 }

--- a/examples/react/w3console/src/components/Uploader.tsx
+++ b/examples/react/w3console/src/components/Uploader.tsx
@@ -17,10 +17,10 @@ export const Uploading = ({
   file?: File
   storedDAGShards?: CARMetadata[]
 }): JSX.Element => (
-  <div className='flex flex-col items-center'>
+  <div className='flex flex-col items-center w-full'>
     <h1 className='font-bold text-sm uppercase text-gray-400'>Uploading {file?.name}</h1>
     {storedDAGShards?.map(({ cid, size }) => (
-      <p className='text-xs' key={cid.toString()}>
+      <p className='text-xs max-w-full overflow-hidden text-ellipsis' key={cid.toString()}>
         shard {cid.toString()} ({humanFileSize(size)}) uploaded
       </p>
     ))}
@@ -46,10 +46,10 @@ export const Done = ({ dataCID }: DoneProps): JSX.Element => {
   const [, { setFile }] = useUploaderComponent()
   const cid: string = dataCID?.toString() ?? ''
   return (
-    <div className='flex flex-col items-center'>
-      <h1 className='font-bold text-sm uppercase text-gray-400 mb-1'>Uploaded</h1>
+    <div className='flex flex-col items-center w-full'>
+      <h1 className='font-bold text-sm uppercase text-gray-400 mb-1 '>Uploaded</h1>
       <a
-        className='font-mono text-xs'
+        className='font-mono text-xs max-w-full overflow-hidden no-wrap text-ellipsis'
         href={`https://${cid}.ipfs.${gatewayHost}/`}
       >
         {cid}
@@ -136,9 +136,9 @@ const UploaderContents = (): JSX.Element => {
       : <></>
   } else {
     return (
-      <div>
+      <>
         <UploaderConsole />
-      </div>
+      </>
     )
   }
 }

--- a/examples/react/w3console/src/components/UploadsList.tsx
+++ b/examples/react/w3console/src/components/UploadsList.tsx
@@ -24,7 +24,7 @@ function Uploads ({ uploads, loading }: UploadsProps): JSX.Element {
     : (
       <>
         <div className='rounded-md border border-zinc-300'>
-          <table className='border-collapse w-full  divide-y divide-zinc-300'>
+          <table className='border-collapse table-fixed w-full divide-y divide-zinc-300'>
             <thead className='text-left text-sm text-zinc-300'>
               <tr>
                 <th className="p-3">Root CID</th>
@@ -33,7 +33,7 @@ function Uploads ({ uploads, loading }: UploadsProps): JSX.Element {
             <tbody>
               {uploads.map(({ root }) => (
                 <tr key={root.toString()}>
-                  <td className="w-64 p-2 pl-3 font-mono text-sm">
+                  <td className="p-2 pl-3 font-mono text-sm overflow-hidden no-wrap text-ellipsis">
                     <a href={`https://${root.toString()}.ipfs.${gatewayHost}/`}>
                       {root.toString()}
                     </a>

--- a/examples/react/w3console/src/pages/index.tsx
+++ b/examples/react/w3console/src/pages/index.tsx
@@ -86,11 +86,11 @@ function SpaceSection (props: SpaceSectionProps): JSX.Element {
               )}?d=identicon`}
               className='w-10 hover:saturate-200 saturate-0 invert border-solid border-gray-500 border'
             />
-            <div className='grow'>
-              <h1 className='text-xl font-semibold leading-5'>
+            <div className='grow overflow-hidden whitespace-nowrap text-ellipsis text-gray-500'>
+              <h1 className='text-xl font-semibold leading-5 text-white'>
                 {space.name() ?? 'Untitled'}
               </h1>
-              <label className='font-mono text-xs text-gray-500'>
+              <label className='font-mono text-xs'>
                 {space.did()}
               </label>
             </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,8 +234,8 @@ importers:
 
   examples/react/w3console:
     specifiers:
-      '@headlessui/react': ^1.7.7
-      '@heroicons/react': ^2.0.13
+      '@headlessui/react': ^1.7.13
+      '@heroicons/react': ^2.0.17
       '@ipld/car': ^5.1.0
       '@ipld/dag-ucan': ^3.2.0
       '@preact/preset-vite': ^2.4.0
@@ -256,8 +256,8 @@ importers:
       typescript: ^4.9.3
       vite: ^4.0.0
     dependencies:
-      '@headlessui/react': 1.7.7
-      '@heroicons/react': 2.0.13
+      '@headlessui/react': 1.7.13
+      '@heroicons/react': 2.0.17
       '@ipld/car': 5.1.0
       '@ipld/dag-ucan': 3.2.0
       '@w3ui/keyring-core': link:../../../packages/keyring-core
@@ -3274,6 +3274,16 @@ packages:
     resolution: {integrity: sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==}
     dev: true
 
+  /@headlessui/react/1.7.13:
+    resolution: {integrity: sha512-9n+EQKRtD9266xIHXdY5MfiXPDfYwl7zBM7KOx2Ae3Gdgxy8QML1FkCMjq6AsOf0l6N9uvI4HcFtuFlenaldKg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^16 || ^17 || ^18
+      react-dom: ^16 || ^17 || ^18
+    dependencies:
+      client-only: 0.0.1
+    dev: false
+
   /@headlessui/react/1.7.7:
     resolution: {integrity: sha512-BqDOd/tB9u2tA0T3Z0fn18ktw+KbVwMnkxxsGPIH2hzssrQhKB5n/6StZOyvLYP/FsYtvuXfi9I0YowKPv2c1w==}
     engines: {node: '>=10'}
@@ -3286,6 +3296,12 @@ packages:
 
   /@heroicons/react/2.0.13:
     resolution: {integrity: sha512-iSN5XwmagrnirWlYEWNPdCDj9aRYVD/lnK3JlsC9/+fqGF80k8C7rl+1HCvBX0dBoagKqOFBs6fMhJJ1hOg1EQ==}
+    peerDependencies:
+      react: '>= 16'
+    dev: false
+
+  /@heroicons/react/2.0.17:
+    resolution: {integrity: sha512-90GMZktkA53YbNzHp6asVEDevUQCMtxWH+2UK2S8OpnLEu7qckTJPhNxNQG52xIR1WFTwFqtH6bt7a60ZNcLLA==}
     peerDependencies:
       react: '>= 16'
     dev: false


### PR DESCRIPTION
Plenty of polish we could still do, but this takes care of the most egregious problems on smaller screens:

https://user-images.githubusercontent.com/1113/230239853-c93deef4-f8fd-426c-8002-1a8ff192cd5c.mov

We're using HeadlessUI's Dialog and Transition components to make the small-screen sidebar feel nice.