### PR TITLE
feat: implement `uploadCAR` in uploader

### DIFF
--- a/docs/uploader-core.md
+++ b/docs/uploader-core.md
@@ -21,6 +21,7 @@ import * as UploaderCore from '@w3ui/uploader-core'
 **Functions**
 - [`uploadFile`](#uploadfile)
 - [`uploadDirectory`](#uploaddirectory)
+- [`uploadCAR`](#uploadcar)
 
 ---
 
@@ -47,3 +48,7 @@ Re-exported [`uploadFile` function](https://github.com/web3-storage/w3protocol/t
 ### `uploadDirectory`
 
 Re-exported [`uploadDirectory` function](https://github.com/web3-storage/w3protocol/tree/main/packages/upload-client#uploaddirectory) from `@web3-storage/upload-client`.
+
+### `uploadCAR`
+
+Re-exported [`uploadCAR` function](https://github.com/web3-storage/w3protocol/tree/main/packages/upload-client#uploadcar) from `@web3-storage/upload-client`.

--- a/packages/react-uploader/src/Uploader.tsx
+++ b/packages/react-uploader/src/Uploader.tsx
@@ -81,6 +81,9 @@ const UploaderComponentContext = createContext<UploaderComponentContextValue>([
     },
     uploadDirectory: async () => {
       throw new Error('missing uploader context provider')
+    },
+    uploadCAR: async () => {
+      throw new Error('missing uploader context provider')
     }
   }
 ])

--- a/packages/uploader-core/src/index.ts
+++ b/packages/uploader-core/src/index.ts
@@ -3,7 +3,7 @@ import type { ConnectionView, Principal } from '@ucanto/interface'
 
 import { Link, Version } from 'multiformats'
 
-export { uploadFile, uploadDirectory } from '@web3-storage/upload-client'
+export { uploadFile, uploadDirectory, uploadCAR } from '@web3-storage/upload-client'
 
 export type { CARMetadata, Service, ProgressFn, ProgressStatus, FetchOptions }
 
@@ -31,4 +31,8 @@ export interface UploaderContextActions {
   uploadDirectory: (
     files: File[]
   ) => Promise<CID>
+  /**
+   * Upload a CAR file containing a DAG to the current space.
+   */
+  uploadCAR: (car: Blob) => Promise<CID>
 }


### PR DESCRIPTION
This exposes the `upload-client`'s `uploadCAR` function in the `UploaderProvider`.

I need to be able to access this to upload merkle clock events generated by bucket mutations to w3up.