### PR TITLE
docs: add note in solid example about KeyringProvider

### DIFF
--- a/examples/solid/sign-up-in/src/ContentPage.jsx
+++ b/examples/solid/sign-up-in/src/ContentPage.jsx
@@ -1,10 +1,18 @@
-import { createSignal, Switch, Match } from 'solid-js'
+import { createSignal, Switch, Match, createEffect } from 'solid-js'
 import { useKeyring } from '@w3ui/solid-keyring'
 
 export default function ContentPage () {
+  // note: depends on KeyringProvider
   const [keyring, { authorize, cancelAuthorize, loadAgent, unloadAgent }] = useKeyring()
   const [email, setEmail] = createSignal('')
   const [submitted, setSubmitted] = createSignal(false)
+
+  createEffect(() => {
+    console.log({keyring})
+  })
+  createEffect(() => {
+    console.log({keyring,e:email(),s:submitted()})
+  })
 
   loadAgent() // try load agent - once.
 


### PR DESCRIPTION
took be a bit to notice
see https://discordapp.com/channels/806902334369824788/864892166470893588/1118953294514094201

Better solution would probably be to throw an error if there is no provider :thinking: 