### PR TITLE
bump solid and export keyring from uploader

### DIFF
--- a/examples/solid/file-upload/package.json
+++ b/examples/solid/file-upload/package.json
@@ -17,6 +17,6 @@
   "dependencies": {
     "@w3ui/solid-keyring": "workspace:^",
     "@w3ui/solid-uploader": "workspace:^",
-    "solid-js": "^1.7.8"
+    "solid-js": "^1.7.11"
   }
 }

--- a/examples/solid/multi-file-upload/package.json
+++ b/examples/solid/multi-file-upload/package.json
@@ -17,6 +17,6 @@
   "dependencies": {
     "@w3ui/solid-keyring": "workspace:^",
     "@w3ui/solid-uploader": "workspace:^",
-    "solid-js": "^1.7.8"
+    "solid-js": "^1.7.11"
   }
 }

--- a/examples/solid/sign-up-in/package.json
+++ b/examples/solid/sign-up-in/package.json
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@w3ui/solid-keyring": "workspace:^",
-    "solid-js": "^1.7.8"
+    "solid-js": "^1.7.11"
   }
 }

--- a/examples/solid/template/package.json
+++ b/examples/solid/template/package.json
@@ -15,6 +15,6 @@
     "vite-plugin-solid": "^2.7.0"
   },
   "dependencies": {
-    "solid-js": "^1.7.8"
+    "solid-js": "^1.7.11"
   }
 }

--- a/examples/solid/uploads-list/package.json
+++ b/examples/solid/uploads-list/package.json
@@ -17,6 +17,6 @@
   "dependencies": {
     "@w3ui/solid-keyring": "workspace:^",
     "@w3ui/solid-uploads-list": "workspace:^",
-    "solid-js": "^1.7.8"
+    "solid-js": "^1.7.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-visualizer": "^5.9.0",
     "serve": "^14.2.0",
-    "solid-js": "^1.6.10",
+    "solid-js": "^1.7.11",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4",
     "vitest": "^0.27.3",

--- a/packages/solid-keyring/package.json
+++ b/packages/solid-keyring/package.json
@@ -33,7 +33,7 @@
     "@w3ui/keyring-core": "workspace:^"
   },
   "peerDependencies": {
-    "solid-js": "^1.7.8"
+    "solid-js": "^1.7.11"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/solid-uploader/package.json
+++ b/packages/solid-uploader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@w3ui/solid-uploader",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Solid adapter for w3ui uploader.",
   "main": "src/index.ts",
   "publishConfig": {
@@ -34,7 +34,7 @@
     "multiformats": "^11.0.1"
   },
   "peerDependencies": {
-    "solid-js": "^1.7.8"
+    "solid-js": "^1.7.11"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/solid-uploader/src/index.ts
+++ b/packages/solid-uploader/src/index.ts
@@ -1,3 +1,4 @@
 export type { Service, CARMetadata, CID, ProgressFn, ProgressStatus, FetchOptions } from '@w3ui/uploader-core'
 export { uploadFile, uploadDirectory } from '@w3ui/uploader-core'
 export * from './providers/Uploader'
+export { KeyringProvider, useKeyring } from '@w3ui/solid-keyring'

--- a/packages/solid-uploads-list/package.json
+++ b/packages/solid-uploads-list/package.json
@@ -33,7 +33,7 @@
     "@web3-storage/capabilities": "^7.0.0"
   },
   "peerDependencies": {
-    "solid-js": "^1.7.8"
+    "solid-js": "^1.7.11"
   },
   "devDependencies": {
     "@ucanto/interface": "^8.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 importers:
 
@@ -95,8 +99,8 @@ importers:
         specifier: ^14.2.0
         version: 14.2.0
       solid-js:
-        specifier: ^1.6.10
-        version: 1.7.5
+        specifier: ^1.7.11
+        version: 1.7.11
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@types/node@20.1.5)(typescript@4.9.5)
@@ -314,15 +318,15 @@ importers:
         specifier: workspace:^
         version: link:../../../packages/solid-uploader
       solid-js:
-        specifier: ^1.7.8
-        version: 1.7.8
+        specifier: ^1.7.11
+        version: 1.7.11
     devDependencies:
       vite:
         specifier: ^4.3.9
         version: 4.3.9(@types/node@20.1.5)
       vite-plugin-solid:
         specifier: ^2.7.0
-        version: 2.7.0(solid-js@1.7.8)(vite@4.3.9)
+        version: 2.7.0(solid-js@1.7.11)(vite@4.3.9)
 
   examples/solid/multi-file-upload:
     dependencies:
@@ -333,15 +337,15 @@ importers:
         specifier: workspace:^
         version: link:../../../packages/solid-uploader
       solid-js:
-        specifier: ^1.7.8
-        version: 1.7.8
+        specifier: ^1.7.11
+        version: 1.7.11
     devDependencies:
       vite:
         specifier: ^4.3.9
         version: 4.3.9(@types/node@20.1.5)
       vite-plugin-solid:
         specifier: ^2.7.0
-        version: 2.7.0(solid-js@1.7.8)(vite@4.3.9)
+        version: 2.7.0(solid-js@1.7.11)(vite@4.3.9)
 
   examples/solid/sign-up-in:
     dependencies:
@@ -349,28 +353,28 @@ importers:
         specifier: workspace:^
         version: link:../../../packages/solid-keyring
       solid-js:
-        specifier: ^1.7.8
-        version: 1.7.8
+        specifier: ^1.7.11
+        version: 1.7.11
     devDependencies:
       vite:
         specifier: ^4.3.9
         version: 4.3.9(@types/node@20.1.5)
       vite-plugin-solid:
         specifier: ^2.7.0
-        version: 2.7.0(solid-js@1.7.8)(vite@4.3.9)
+        version: 2.7.0(solid-js@1.7.11)(vite@4.3.9)
 
   examples/solid/template:
     dependencies:
       solid-js:
-        specifier: ^1.7.8
-        version: 1.7.8
+        specifier: ^1.7.11
+        version: 1.7.11
     devDependencies:
       vite:
         specifier: ^4.3.9
         version: 4.3.9(@types/node@20.1.5)
       vite-plugin-solid:
         specifier: ^2.7.0
-        version: 2.7.0(solid-js@1.7.8)(vite@4.3.9)
+        version: 2.7.0(solid-js@1.7.11)(vite@4.3.9)
 
   examples/solid/uploads-list:
     dependencies:
@@ -381,15 +385,15 @@ importers:
         specifier: workspace:^
         version: link:../../../packages/solid-uploads-list
       solid-js:
-        specifier: ^1.7.8
-        version: 1.7.8
+        specifier: ^1.7.11
+        version: 1.7.11
     devDependencies:
       vite:
         specifier: ^4.3.9
         version: 4.3.9(@types/node@20.1.5)
       vite-plugin-solid:
         specifier: ^2.7.0
-        version: 2.7.0(solid-js@1.7.8)(vite@4.3.9)
+        version: 2.7.0(solid-js@1.7.11)(vite@4.3.9)
 
   examples/test/playwright:
     devDependencies:
@@ -630,8 +634,8 @@ importers:
         specifier: workspace:^
         version: link:../keyring-core
       solid-js:
-        specifier: ^1.7.8
-        version: 1.7.8
+        specifier: ^1.7.11
+        version: 1.7.11
 
   packages/solid-uploader:
     dependencies:
@@ -648,8 +652,8 @@ importers:
         specifier: ^11.0.1
         version: 11.0.2
       solid-js:
-        specifier: ^1.7.8
-        version: 1.7.8
+        specifier: ^1.7.11
+        version: 1.7.11
 
   packages/solid-uploads-list:
     dependencies:
@@ -663,8 +667,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       solid-js:
-        specifier: ^1.7.8
-        version: 1.7.8
+        specifier: ^1.7.11
+        version: 1.7.11
     devDependencies:
       '@ucanto/interface':
         specifier: ^8.0.0
@@ -8211,20 +8215,13 @@ packages:
       is-fullwidth-code-point: 4.0.0
     dev: true
 
-  /solid-js@1.7.5:
-    resolution: {integrity: sha512-GfJ8na1e9FG1oAF5xC24BM+ATLym0sfH+ZblkbBFpueYdq3fWAoA5Ve+jGeIeLI7jmMGfa0rUaKruszNm2sH8w==}
-    dependencies:
-      csstype: 3.1.2
-      seroval: 0.5.1
-    dev: true
-
-  /solid-js@1.7.8:
-    resolution: {integrity: sha512-XHBWk1FvFd0JMKljko7FfhefJMTSgYEuVKcQ2a8hzRXfiuSJAGsrPPafqEo+f6l+e8Oe3cROSpIL6kbzjC1fjQ==}
+  /solid-js@1.7.11:
+    resolution: {integrity: sha512-JkuvsHt8jqy7USsy9xJtT18aF9r2pFO+GB8JQ2XGTvtF49rGTObB46iebD25sE3qVNvIbwglXOXdALnJq9IHtQ==}
     dependencies:
       csstype: 3.1.2
       seroval: 0.5.1
 
-  /solid-refresh@0.5.2(solid-js@1.7.8):
+  /solid-refresh@0.5.2(solid-js@1.7.11):
     resolution: {integrity: sha512-I69HmFj0LsGRJ3n8CEMVjyQFgVtuM2bSjznu2hCnsY+i5oOxh8ioWj00nnHBv0UYD3WpE/Sq4Q3TNw2IKmKN7A==}
     peerDependencies:
       solid-js: ^1.3
@@ -8232,7 +8229,7 @@ packages:
       '@babel/generator': 7.22.9
       '@babel/helper-module-imports': 7.22.5
       '@babel/types': 7.22.5
-      solid-js: 1.7.8
+      solid-js: 1.7.11
     dev: true
 
   /source-map-js@1.0.2:
@@ -8909,7 +8906,7 @@ packages:
       - supports-color
       - terser
 
-  /vite-plugin-solid@2.7.0(solid-js@1.7.8)(vite@4.3.9):
+  /vite-plugin-solid@2.7.0(solid-js@1.7.11)(vite@4.3.9):
     resolution: {integrity: sha512-avp/Jl5zOp/Itfo67xtDB2O61U7idviaIp4mLsjhCa13PjKNasz+IID0jYTyqUp9SFx6/PmBr6v4KgDppqompg==}
     peerDependencies:
       solid-js: ^1.7.2
@@ -8920,8 +8917,8 @@ packages:
       '@types/babel__core': 7.20.0
       babel-preset-solid: 1.7.4(@babel/core@7.22.9)
       merge-anything: 5.1.6
-      solid-js: 1.7.8
-      solid-refresh: 0.5.2(solid-js@1.7.8)
+      solid-js: 1.7.11
+      solid-refresh: 0.5.2(solid-js@1.7.11)
       vite: 4.3.9(@types/node@20.1.5)
       vitefu: 0.2.4(vite@4.3.9)
     transitivePeerDependencies:


### PR DESCRIPTION
I noticed that the keyring code was double bundled (and at a hefty 200k+ this feels relevant)

Not sure if this strategy is solid (pun intended), but i tried to reexport keyring from uploader.

Initial tests with mapex indicate success, but I need feedback if it actually makes sense, 
and it would need testing from the team for bundling and importing in different scenarios 

perhaps `export * from  '@w3ui/solid-keyring'` would make more sense, but i just exported what i need for now.