### PR TITLE
fix: bump access package to stop using voucher protocol

### DIFF
--- a/packages/keyring-core/package.json
+++ b/packages/keyring-core/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@ucanto/interface": "^8.0.0",
     "@ucanto/principal": "^8.0.0",
-    "@web3-storage/access": "^15.0.0"
+    "@web3-storage/access": "^15.2.0"
   },
   "eslintConfig": {
     "extends": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,4 @@
-lockfileVersion: '6.0'
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
+lockfileVersion: '6.1'
 
 importers:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 importers:
 
@@ -537,8 +541,8 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
       '@web3-storage/access':
-        specifier: ^15.0.0
-        version: 15.0.0(typescript@4.9.5)
+        specifier: ^15.2.0
+        version: 15.2.0(typescript@4.9.5)
 
   packages/react-keyring:
     dependencies:
@@ -2799,6 +2803,11 @@ packages:
   /@noble/ed25519@1.7.3:
     resolution: {integrity: sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==}
 
+  /@noble/hashes@1.3.2:
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
+    dev: false
+
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -3654,8 +3663,8 @@ packages:
       web-streams-polyfill: 3.2.1
     dev: false
 
-  /@web3-storage/access@15.0.0(typescript@4.9.5):
-    resolution: {integrity: sha512-z6sg/UyUhHyn+spRGeUnW44P3YoNq7g5qTG+hBj4aEKjIeRKqC4V+cYE2Bqwp2HkyJk2oMKzznjwTwCJDNoVeA==}
+  /@web3-storage/access@15.2.0(typescript@4.9.5):
+    resolution: {integrity: sha512-515WwZZLs2M0Dau3JGgroyK0a6fcuREcFv+i2EjUMLW8neYP7k8j++rpOjBSUNIIHkBbYtqx2aeX6fzmmEPriw==}
     hasBin: true
     dependencies:
       '@ipld/car': 5.1.1
@@ -3666,7 +3675,7 @@ packages:
       '@ucanto/principal': 8.0.0
       '@ucanto/transport': 8.0.0
       '@ucanto/validator': 8.0.0
-      '@web3-storage/capabilities': 7.0.0
+      '@web3-storage/capabilities': 9.2.1
       '@web3-storage/did-mailto': 2.0.0
       bigint-mod-arith: 3.2.1
       conf: 10.2.0
@@ -3706,6 +3715,24 @@ packages:
       '@ucanto/principal': 8.0.0
       '@ucanto/transport': 8.0.0
       '@ucanto/validator': 8.0.0
+
+  /@web3-storage/capabilities@9.2.1:
+    resolution: {integrity: sha512-NBXm9320grYtKYV7g8nI7zzzS6GfOPp7EmDeWxDwOZ3nHvXDuiR77e3Sf7rRY265rMyJCtRUJ7/qRk7unQSfmA==}
+    dependencies:
+      '@ucanto/core': 8.0.0
+      '@ucanto/interface': 8.0.0
+      '@ucanto/principal': 8.0.0
+      '@ucanto/transport': 8.0.0
+      '@ucanto/validator': 8.0.0
+      '@web3-storage/data-segment': 3.0.1
+    dev: false
+
+  /@web3-storage/data-segment@3.0.1:
+    resolution: {integrity: sha512-+e0KeqofejZ/1JLCdNmlEMCCSNf0PeJFXA/2Vw5+vWj4Nfko8sVLIGva86L8hXzm4dZGhWYU5m6JhX2U2Wn5Dg==}
+    dependencies:
+      multiformats: 11.0.2
+      sync-multihash-sha2: 1.0.0
+    dev: false
 
   /@web3-storage/did-mailto@2.0.0:
     resolution: {integrity: sha512-y0uWnAG6V0PmKCPQdiSc8eR+yOpj3kyRqlm4ByNZcYd/HUT5t9UzUFMBO7hks14JOTUbV2bphHMToBS9u+f1GQ==}
@@ -8461,6 +8488,12 @@ packages:
 
   /symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  /sync-multihash-sha2@1.0.0:
+    resolution: {integrity: sha512-A5gVpmtKF0ov+/XID0M0QRJqF2QxAsj3x/LlDC8yivzgoYCoWkV+XaZPfVu7Vj1T/hYzYS1tfjwboSbXjqocug==}
+    dependencies:
+      '@noble/hashes': 1.3.2
+    dev: false
 
   /tailwindcss@3.3.2(ts-node@10.9.1):
     resolution: {integrity: sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==}


### PR DESCRIPTION
@web3-storage/access-client@15.0.0 was mistakenly built with code that can use the voucher protocol. update to 15.2.0 to fix https://github.com/web3-storage/w3ui/issues/545