### PR TITLE
fix: bump keyring package versions to bring in latest keyring-core

### DIFF
--- a/packages/react-keyring/package.json
+++ b/packages/react-keyring/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/react-keyring",
   "dependencies": {
-    "@w3ui/keyring-core": "workspace:^",
+    "@w3ui/keyring-core": "workspace:^5.0.1",
     "ariakit-react-utils": "0.17.0-next.27",
     "use-local-storage-state": "^18.2.1"
   },

--- a/packages/solid-keyring/package.json
+++ b/packages/solid-keyring/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@ucanto/interface": "^8.0.0",
     "@ucanto/principal": "^8.0.0",
-    "@w3ui/keyring-core": "workspace:^"
+    "@w3ui/keyring-core": "workspace:^5.0.1"
   },
   "peerDependencies": {
     "solid-js": "^1.7.8"

--- a/packages/vue-keyring/package.json
+++ b/packages/vue-keyring/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/vue-keyring",
   "dependencies": {
-    "@w3ui/keyring-core": "workspace:^"
+    "@w3ui/keyring-core": "workspace:^5.0.1"
   },
   "peerDependencies": {
     "vue": "^3.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,4 @@
-lockfileVersion: '6.0'
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
+lockfileVersion: '6.1'
 
 importers:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 importers:
 
@@ -543,7 +547,7 @@ importers:
   packages/react-keyring:
     dependencies:
       '@w3ui/keyring-core':
-        specifier: workspace:^
+        specifier: workspace:^5.0.1
         version: link:../keyring-core
       ariakit-react-utils:
         specifier: 0.17.0-next.27
@@ -627,7 +631,7 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
       '@w3ui/keyring-core':
-        specifier: workspace:^
+        specifier: workspace:^5.0.1
         version: link:../keyring-core
       solid-js:
         specifier: ^1.7.8
@@ -700,7 +704,7 @@ importers:
   packages/vue-keyring:
     dependencies:
       '@w3ui/keyring-core':
-        specifier: workspace:^
+        specifier: workspace:^5.0.1
         version: link:../keyring-core
       vue:
         specifier: ^3.0.0


### PR DESCRIPTION
this fixes an issue where we were using a broken version of access-client