### PR TITLE
fix: set minimum workspace dep versions to bump package numbers

### DIFF
--- a/packages/react-uploader/package.json
+++ b/packages/react-uploader/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/react-uploader",
   "dependencies": {
-    "@w3ui/react-keyring": "workspace:^",
+    "@w3ui/react-keyring": "workspace:^6.0.1",
     "@w3ui/uploader-core": "workspace:^",
     "@web3-storage/capabilities": "^7.0.0",
     "ariakit-react-utils": "0.17.0-next.27"

--- a/packages/react-uploads-list/package.json
+++ b/packages/react-uploads-list/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/react-uploads-list",
   "dependencies": {
-    "@w3ui/react-keyring": "workspace:^",
+    "@w3ui/react-keyring": "workspace:^6.0.1",
     "@w3ui/uploads-list-core": "workspace:^",
     "@web3-storage/capabilities": "^7.0.0",
     "ariakit-react-utils": "0.17.0-next.27"

--- a/packages/solid-uploader/package.json
+++ b/packages/solid-uploader/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/solid-uploader",
   "dependencies": {
-    "@w3ui/solid-keyring": "workspace:^",
+    "@w3ui/solid-keyring": "workspace:^5.0.1",
     "@w3ui/uploader-core": "workspace:^",
     "@web3-storage/capabilities": "^7.0.0",
     "multiformats": "^11.0.1"

--- a/packages/solid-uploads-list/package.json
+++ b/packages/solid-uploads-list/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/solid-uploads-list",
   "dependencies": {
-    "@w3ui/solid-keyring": "workspace:^",
+    "@w3ui/solid-keyring": "workspace:^5.0.1",
     "@w3ui/uploads-list-core": "workspace:^",
     "@web3-storage/capabilities": "^7.0.0"
   },

--- a/packages/vue-uploader/package.json
+++ b/packages/vue-uploader/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/vue-uploader",
   "dependencies": {
     "@w3ui/uploader-core": "workspace:^",
-    "@w3ui/vue-keyring": "workspace:^",
+    "@w3ui/vue-keyring": "workspace:^5.0.1",
     "@web3-storage/capabilities": "^7.0.0",
     "multiformats": "^11.0.1"
   },

--- a/packages/vue-uploads-list/package.json
+++ b/packages/vue-uploads-list/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/vue-uploads-list",
   "dependencies": {
     "@w3ui/uploads-list-core": "workspace:^",
-    "@w3ui/vue-keyring": "workspace:^",
+    "@w3ui/vue-keyring": "workspace:^5.0.1",
     "@web3-storage/capabilities": "^7.0.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -571,7 +571,7 @@ importers:
   packages/react-uploader:
     dependencies:
       '@w3ui/react-keyring':
-        specifier: workspace:^
+        specifier: workspace:^6.0.1
         version: link:../react-keyring
       '@w3ui/uploader-core':
         specifier: workspace:^
@@ -596,7 +596,7 @@ importers:
   packages/react-uploads-list:
     dependencies:
       '@w3ui/react-keyring':
-        specifier: workspace:^
+        specifier: workspace:^6.0.1
         version: link:../react-keyring
       '@w3ui/uploads-list-core':
         specifier: workspace:^
@@ -636,7 +636,7 @@ importers:
   packages/solid-uploader:
     dependencies:
       '@w3ui/solid-keyring':
-        specifier: workspace:^
+        specifier: workspace:^5.0.1
         version: link:../solid-keyring
       '@w3ui/uploader-core':
         specifier: workspace:^
@@ -654,7 +654,7 @@ importers:
   packages/solid-uploads-list:
     dependencies:
       '@w3ui/solid-keyring':
-        specifier: workspace:^
+        specifier: workspace:^5.0.1
         version: link:../solid-keyring
       '@w3ui/uploads-list-core':
         specifier: workspace:^
@@ -719,7 +719,7 @@ importers:
         specifier: workspace:^
         version: link:../uploader-core
       '@w3ui/vue-keyring':
-        specifier: workspace:^
+        specifier: workspace:^5.0.1
         version: link:../vue-keyring
       '@web3-storage/capabilities':
         specifier: ^7.0.0
@@ -737,7 +737,7 @@ importers:
         specifier: workspace:^
         version: link:../uploads-list-core
       '@w3ui/vue-keyring':
-        specifier: workspace:^
+        specifier: workspace:^5.0.1
         version: link:../vue-keyring
       '@web3-storage/capabilities':
         specifier: ^7.0.0


### PR DESCRIPTION
this deploys changes that fully deprecate the old voucher protocol