### PR TITLE
feat: re-export Service from `react-keyring`

### DIFF
--- a/packages/react-keyring/package.json
+++ b/packages/react-keyring/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/react-keyring",
   "dependencies": {
-    "@w3ui/keyring-core": "workspace:^5.0.1",
+    "@w3ui/keyring-core": "workspace:^",
     "ariakit-react-utils": "0.17.0-next.27",
     "use-local-storage-state": "^18.2.1"
   },

--- a/packages/react-keyring/src/index.ts
+++ b/packages/react-keyring/src/index.ts
@@ -1,3 +1,3 @@
-export type { Space } from '@w3ui/keyring-core'
+export type { Space, Service } from '@w3ui/keyring-core'
 export * from './providers/Keyring'
 export * from './Authenticator'

--- a/packages/react-uploader/package.json
+++ b/packages/react-uploader/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/react-uploader",
   "dependencies": {
-    "@w3ui/react-keyring": "workspace:^6.0.1",
+    "@w3ui/react-keyring": "workspace:^",
     "@w3ui/uploader-core": "workspace:^",
     "@web3-storage/capabilities": "^11.1.0",
     "ariakit-react-utils": "0.17.0-next.27"

--- a/packages/react-uploads-list/package.json
+++ b/packages/react-uploads-list/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/react-uploads-list",
   "dependencies": {
-    "@w3ui/react-keyring": "workspace:^6.0.1",
+    "@w3ui/react-keyring": "workspace:^",
     "@w3ui/uploads-list-core": "workspace:^",
     "@web3-storage/capabilities": "^11.1.0",
     "ariakit-react-utils": "0.17.0-next.27"

--- a/packages/solid-keyring/package.json
+++ b/packages/solid-keyring/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@ucanto/interface": "^9.0.0",
     "@ucanto/principal": "^9.0.0",
-    "@w3ui/keyring-core": "workspace:^5.0.1"
+    "@w3ui/keyring-core": "workspace:^"
   },
   "peerDependencies": {
     "solid-js": "^1.7.8"

--- a/packages/solid-uploader/package.json
+++ b/packages/solid-uploader/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/solid-uploader",
   "dependencies": {
-    "@w3ui/solid-keyring": "workspace:^5.0.1",
+    "@w3ui/solid-keyring": "workspace:^",
     "@w3ui/uploader-core": "workspace:^",
     "@web3-storage/capabilities": "^11.1.0",
     "multiformats": "^11.0.1"

--- a/packages/solid-uploads-list/package.json
+++ b/packages/solid-uploads-list/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/solid-uploads-list",
   "dependencies": {
-    "@w3ui/solid-keyring": "workspace:^5.0.1",
+    "@w3ui/solid-keyring": "workspace:^",
     "@w3ui/uploads-list-core": "workspace:^",
     "@web3-storage/capabilities": "^11.1.0"
   },

--- a/packages/vue-keyring/package.json
+++ b/packages/vue-keyring/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/vue-keyring",
   "dependencies": {
-    "@w3ui/keyring-core": "workspace:^5.0.1"
+    "@w3ui/keyring-core": "workspace:^"
   },
   "peerDependencies": {
     "vue": "^3.0.0"

--- a/packages/vue-uploader/package.json
+++ b/packages/vue-uploader/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/vue-uploader",
   "dependencies": {
     "@w3ui/uploader-core": "workspace:^",
-    "@w3ui/vue-keyring": "workspace:^5.0.1",
+    "@w3ui/vue-keyring": "workspace:^",
     "@web3-storage/capabilities": "^11.1.0",
     "multiformats": "^11.0.1"
   },

--- a/packages/vue-uploads-list/package.json
+++ b/packages/vue-uploads-list/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/vue-uploads-list",
   "dependencies": {
     "@w3ui/uploads-list-core": "workspace:^",
-    "@w3ui/vue-keyring": "workspace:^5.0.1",
+    "@w3ui/vue-keyring": "workspace:^",
     "@web3-storage/capabilities": "^11.1.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -550,7 +550,7 @@ importers:
   packages/react-keyring:
     dependencies:
       '@w3ui/keyring-core':
-        specifier: workspace:^5.0.1
+        specifier: workspace:^
         version: link:../keyring-core
       ariakit-react-utils:
         specifier: 0.17.0-next.27
@@ -578,7 +578,7 @@ importers:
   packages/react-uploader:
     dependencies:
       '@w3ui/react-keyring':
-        specifier: workspace:^6.0.1
+        specifier: workspace:^
         version: link:../react-keyring
       '@w3ui/uploader-core':
         specifier: workspace:^
@@ -603,7 +603,7 @@ importers:
   packages/react-uploads-list:
     dependencies:
       '@w3ui/react-keyring':
-        specifier: workspace:^6.0.1
+        specifier: workspace:^
         version: link:../react-keyring
       '@w3ui/uploads-list-core':
         specifier: workspace:^
@@ -634,7 +634,7 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0
       '@w3ui/keyring-core':
-        specifier: workspace:^5.0.1
+        specifier: workspace:^
         version: link:../keyring-core
       solid-js:
         specifier: ^1.7.8
@@ -643,7 +643,7 @@ importers:
   packages/solid-uploader:
     dependencies:
       '@w3ui/solid-keyring':
-        specifier: workspace:^5.0.1
+        specifier: workspace:^
         version: link:../solid-keyring
       '@w3ui/uploader-core':
         specifier: workspace:^
@@ -661,7 +661,7 @@ importers:
   packages/solid-uploads-list:
     dependencies:
       '@w3ui/solid-keyring':
-        specifier: workspace:^5.0.1
+        specifier: workspace:^
         version: link:../solid-keyring
       '@w3ui/uploads-list-core':
         specifier: workspace:^
@@ -707,7 +707,7 @@ importers:
   packages/vue-keyring:
     dependencies:
       '@w3ui/keyring-core':
-        specifier: workspace:^5.0.1
+        specifier: workspace:^
         version: link:../keyring-core
       vue:
         specifier: ^3.0.0
@@ -726,7 +726,7 @@ importers:
         specifier: workspace:^
         version: link:../uploader-core
       '@w3ui/vue-keyring':
-        specifier: workspace:^5.0.1
+        specifier: workspace:^
         version: link:../vue-keyring
       '@web3-storage/capabilities':
         specifier: ^11.1.0
@@ -744,7 +744,7 @@ importers:
         specifier: workspace:^
         version: link:../uploads-list-core
       '@w3ui/vue-keyring':
-        specifier: workspace:^5.0.1
+        specifier: workspace:^
         version: link:../vue-keyring
       '@web3-storage/capabilities':
         specifier: ^11.1.0


### PR DESCRIPTION
so that clients don't need to include a manual dependency on `keyring-core`

also unpin a bunch of workspace deps