### PR TITLE
feat!: pin solid and vue upload packages

### DIFF
--- a/packages/solid-uploader/package.json
+++ b/packages/solid-uploader/package.json
@@ -28,8 +28,8 @@
   },
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/solid-uploader",
   "dependencies": {
-    "@w3ui/solid-keyring": "workspace:^",
-    "@w3ui/uploader-core": "workspace:^",
+    "@w3ui/solid-keyring": "workspace:>=6",
+    "@w3ui/uploader-core": "workspace:>=7",
     "@web3-storage/capabilities": "^11.1.0",
     "multiformats": "^11.0.1"
   },

--- a/packages/solid-uploads-list/package.json
+++ b/packages/solid-uploads-list/package.json
@@ -28,8 +28,8 @@
   },
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/solid-uploads-list",
   "dependencies": {
-    "@w3ui/solid-keyring": "workspace:^",
-    "@w3ui/uploads-list-core": "workspace:^",
+    "@w3ui/solid-keyring": "workspace:>=6",
+    "@w3ui/uploads-list-core": "workspace:>=5",
     "@web3-storage/capabilities": "^11.1.0"
   },
   "peerDependencies": {

--- a/packages/vue-uploader/package.json
+++ b/packages/vue-uploader/package.json
@@ -27,8 +27,8 @@
   },
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/vue-uploader",
   "dependencies": {
-    "@w3ui/uploader-core": "workspace:^",
-    "@w3ui/vue-keyring": "workspace:^",
+    "@w3ui/uploader-core": "workspace:>=7",
+    "@w3ui/vue-keyring": "workspace:>=6",
     "@web3-storage/capabilities": "^11.1.0",
     "multiformats": "^11.0.1"
   },

--- a/packages/vue-uploads-list/package.json
+++ b/packages/vue-uploads-list/package.json
@@ -27,8 +27,8 @@
   },
   "homepage": "https://github.com/web3-storage/w3ui/tree/main/packages/vue-uploads-list",
   "dependencies": {
-    "@w3ui/uploads-list-core": "workspace:^",
-    "@w3ui/vue-keyring": "workspace:^",
+    "@w3ui/uploads-list-core": "workspace:>=5",
+    "@w3ui/vue-keyring": "workspace:>=6",
     "@web3-storage/capabilities": "^11.1.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -661,10 +661,10 @@ importers:
   packages/solid-uploader:
     dependencies:
       '@w3ui/solid-keyring':
-        specifier: workspace:^
+        specifier: workspace:>=6
         version: link:../solid-keyring
       '@w3ui/uploader-core':
-        specifier: workspace:^
+        specifier: workspace:>=7
         version: link:../uploader-core
       '@web3-storage/capabilities':
         specifier: ^11.1.0
@@ -679,10 +679,10 @@ importers:
   packages/solid-uploads-list:
     dependencies:
       '@w3ui/solid-keyring':
-        specifier: workspace:^
+        specifier: workspace:>=6
         version: link:../solid-keyring
       '@w3ui/uploads-list-core':
-        specifier: workspace:^
+        specifier: workspace:>=5
         version: link:../uploads-list-core
       '@web3-storage/capabilities':
         specifier: ^11.1.0
@@ -741,10 +741,10 @@ importers:
   packages/vue-uploader:
     dependencies:
       '@w3ui/uploader-core':
-        specifier: workspace:^
+        specifier: workspace:>=7
         version: link:../uploader-core
       '@w3ui/vue-keyring':
-        specifier: workspace:^
+        specifier: workspace:>=6
         version: link:../vue-keyring
       '@web3-storage/capabilities':
         specifier: ^11.1.0
@@ -759,10 +759,10 @@ importers:
   packages/vue-uploads-list:
     dependencies:
       '@w3ui/uploads-list-core':
-        specifier: workspace:^
+        specifier: workspace:>=5
         version: link:../uploads-list-core
       '@w3ui/vue-keyring':
-        specifier: workspace:^
+        specifier: workspace:>=6
         version: link:../vue-keyring
       '@web3-storage/capabilities':
         specifier: ^11.1.0


### PR DESCRIPTION
We made major releases of their dependencies, so we should make major releases of these so that someone installing one of them in isolation gets the latest keyring and core deps.